### PR TITLE
Migrate to GDScript 2

### DIFF
--- a/addons/voxel-core/assets/classes/voxel.png.import
+++ b/addons/voxel-core/assets/classes/voxel.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/voxel.png-dd64143ceb6a899a7d27aac508889c4a.stex"
+type="StreamTexture2D"
+uid="uid://w8ilsmu0e7t8"
+path="res://.godot/imported/voxel.png-dd64143ceb6a899a7d27aac508889c4a.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/classes/voxel.png"
-dest_files=[ "res://.import/voxel.png-dd64143ceb6a899a7d27aac508889c4a.stex" ]
+dest_files=["res://.godot/imported/voxel.png-dd64143ceb6a899a7d27aac508889c4a.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/classes/voxel_core.png.import
+++ b/addons/voxel-core/assets/classes/voxel_core.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/voxel_core.png-a32ca196c37db7145310427f4db62a3a.stex"
+type="StreamTexture2D"
+uid="uid://b2cmy8jy65ek4"
+path="res://.godot/imported/voxel_core.png-a32ca196c37db7145310427f4db62a3a.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/classes/voxel_core.png"
-dest_files=[ "res://.import/voxel_core.png-a32ca196c37db7145310427f4db62a3a.stex" ]
+dest_files=["res://.godot/imported/voxel_core.png-a32ca196c37db7145310427f4db62a3a.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/classes/voxel_mesh.png.import
+++ b/addons/voxel-core/assets/classes/voxel_mesh.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/voxel_mesh.png-fdbe099c6e210aa233cb4e3c0a8a12a1.stex"
+type="StreamTexture2D"
+uid="uid://dta2uhemfmnmm"
+path="res://.godot/imported/voxel_mesh.png-fdbe099c6e210aa233cb4e3c0a8a12a1.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/classes/voxel_mesh.png"
-dest_files=[ "res://.import/voxel_mesh.png-fdbe099c6e210aa233cb4e3c0a8a12a1.stex" ]
+dest_files=["res://.godot/imported/voxel_mesh.png-fdbe099c6e210aa233cb4e3c0a8a12a1.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/classes/voxel_set.png.import
+++ b/addons/voxel-core/assets/classes/voxel_set.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/voxel_set.png-22b15a472cc87576fbf5d9ffb176d0e3.stex"
+type="StreamTexture2D"
+uid="uid://fgn3hcki4g8b"
+path="res://.godot/imported/voxel_set.png-22b15a472cc87576fbf5d9ffb176d0e3.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/classes/voxel_set.png"
-dest_files=[ "res://.import/voxel_set.png-22b15a472cc87576fbf5d9ffb176d0e3.stex" ]
+dest_files=["res://.godot/imported/voxel_set.png-22b15a472cc87576fbf5d9ffb176d0e3.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/classes/voxel_world.png.import
+++ b/addons/voxel-core/assets/classes/voxel_world.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/voxel_world.png-92700e4046f2e306d3d5d64f2cc531c9.stex"
+type="StreamTexture2D"
+uid="uid://4suf8rd1b7mk"
+path="res://.godot/imported/voxel_world.png-92700e4046f2e306d3d5d64f2cc531c9.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/classes/voxel_world.png"
-dest_files=[ "res://.import/voxel_world.png-92700e4046f2e306d3d5d64f2cc531c9.stex" ]
+dest_files=["res://.godot/imported/voxel_world.png-92700e4046f2e306d3d5d64f2cc531c9.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/about.png.import
+++ b/addons/voxel-core/assets/controls/about.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/about.png-fdcdf3764bf5a8fdadba080dba99a88b.stex"
+type="StreamTexture2D"
+uid="uid://bxsbceajv1f44"
+path="res://.godot/imported/about.png-fdcdf3764bf5a8fdadba080dba99a88b.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/about.png"
-dest_files=[ "res://.import/about.png-fdcdf3764bf5a8fdadba080dba99a88b.stex" ]
+dest_files=["res://.godot/imported/about.png-fdcdf3764bf5a8fdadba080dba99a88b.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/add.png.import
+++ b/addons/voxel-core/assets/controls/add.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/add.png-a5cac4fdeb395610b18264da2a692b24.stex"
+type="StreamTexture2D"
+uid="uid://by67hujw2elw2"
+path="res://.godot/imported/add.png-a5cac4fdeb395610b18264da2a692b24.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/add.png"
-dest_files=[ "res://.import/add.png-a5cac4fdeb395610b18264da2a692b24.stex" ]
+dest_files=["res://.godot/imported/add.png-a5cac4fdeb395610b18264da2a692b24.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/area.png.import
+++ b/addons/voxel-core/assets/controls/area.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/area.png-7f52dbe582835348e059a30546c78d68.stex"
+type="StreamTexture2D"
+uid="uid://cdqmw1xav1ntx"
+path="res://.godot/imported/area.png-7f52dbe582835348e059a30546c78d68.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/area.png"
-dest_files=[ "res://.import/area.png-7f52dbe582835348e059a30546c78d68.stex" ]
+dest_files=["res://.godot/imported/area.png-7f52dbe582835348e059a30546c78d68.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/autosave.png.import
+++ b/addons/voxel-core/assets/controls/autosave.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/autosave.png-86a19041a0dbfb2c147a91f63f9e623b.stex"
+type="StreamTexture2D"
+uid="uid://boswwwfvv600f"
+path="res://.godot/imported/autosave.png-86a19041a0dbfb2c147a91f63f9e623b.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/autosave.png"
-dest_files=[ "res://.import/autosave.png-86a19041a0dbfb2c147a91f63f9e623b.stex" ]
+dest_files=["res://.godot/imported/autosave.png-86a19041a0dbfb2c147a91f63f9e623b.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/cancel.png.import
+++ b/addons/voxel-core/assets/controls/cancel.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/cancel.png-e31e2dc5faff0d5c62dfa166f5c96eb9.stex"
+type="StreamTexture2D"
+uid="uid://bgr8lftfuqi72"
+path="res://.godot/imported/cancel.png-e31e2dc5faff0d5c62dfa166f5c96eb9.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/cancel.png"
-dest_files=[ "res://.import/cancel.png-e31e2dc5faff0d5c62dfa166f5c96eb9.stex" ]
+dest_files=["res://.godot/imported/cancel.png-e31e2dc5faff0d5c62dfa166f5c96eb9.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/commit.png.import
+++ b/addons/voxel-core/assets/controls/commit.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/commit.png-a216b7fa39a4140fcb40b739de83f977.stex"
+type="StreamTexture2D"
+uid="uid://bsj5bwwl7t68q"
+path="res://.godot/imported/commit.png-a216b7fa39a4140fcb40b739de83f977.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/commit.png"
-dest_files=[ "res://.import/commit.png-a216b7fa39a4140fcb40b739de83f977.stex" ]
+dest_files=["res://.godot/imported/commit.png-a216b7fa39a4140fcb40b739de83f977.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/confirm.png.import
+++ b/addons/voxel-core/assets/controls/confirm.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/confirm.png-a1dca69286718e53fdb170de2c5dc2a0.stex"
+type="StreamTexture2D"
+uid="uid://b7gqesgqkwj13"
+path="res://.godot/imported/confirm.png-a1dca69286718e53fdb170de2c5dc2a0.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/confirm.png"
-dest_files=[ "res://.import/confirm.png-a1dca69286718e53fdb170de2c5dc2a0.stex" ]
+dest_files=["res://.godot/imported/confirm.png-a1dca69286718e53fdb170de2c5dc2a0.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/cursor.png.import
+++ b/addons/voxel-core/assets/controls/cursor.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/cursor.png-4919f183c1246e8f6de0aa43fa57e669.stex"
+type="StreamTexture2D"
+uid="uid://bsgxlkcxtpd1m"
+path="res://.godot/imported/cursor.png-4919f183c1246e8f6de0aa43fa57e669.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/cursor.png"
-dest_files=[ "res://.import/cursor.png-4919f183c1246e8f6de0aa43fa57e669.stex" ]
+dest_files=["res://.godot/imported/cursor.png-4919f183c1246e8f6de0aa43fa57e669.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/docs.png.import
+++ b/addons/voxel-core/assets/controls/docs.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/docs.png-1f40ac273e9d9bab073c00e747b08026.stex"
+type="StreamTexture2D"
+uid="uid://bu25gf8sk1hr4"
+path="res://.godot/imported/docs.png-1f40ac273e9d9bab073c00e747b08026.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/docs.png"
-dest_files=[ "res://.import/docs.png-1f40ac273e9d9bab073c00e747b08026.stex" ]
+dest_files=["res://.godot/imported/docs.png-1f40ac273e9d9bab073c00e747b08026.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/down.png.import
+++ b/addons/voxel-core/assets/controls/down.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/down.png-e920e62c852398092f2c7db7a9fb7935.stex"
+type="StreamTexture2D"
+uid="uid://qdrxy7usbxgh"
+path="res://.godot/imported/down.png-e920e62c852398092f2c7db7a9fb7935.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/down.png"
-dest_files=[ "res://.import/down.png-e920e62c852398092f2c7db7a9fb7935.stex" ]
+dest_files=["res://.godot/imported/down.png-e920e62c852398092f2c7db7a9fb7935.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/duplicate.png.import
+++ b/addons/voxel-core/assets/controls/duplicate.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/duplicate.png-2f73b353b427b078fd0fdb0de9e665e0.stex"
+type="StreamTexture2D"
+uid="uid://msr3uk0gka2w"
+path="res://.godot/imported/duplicate.png-2f73b353b427b078fd0fdb0de9e665e0.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/duplicate.png"
-dest_files=[ "res://.import/duplicate.png-2f73b353b427b078fd0fdb0de9e665e0.stex" ]
+dest_files=["res://.godot/imported/duplicate.png-2f73b353b427b078fd0fdb0de9e665e0.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/edit.png.import
+++ b/addons/voxel-core/assets/controls/edit.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/edit.png-446dcdc24343dea15b1b27696f2bd4de.stex"
+type="StreamTexture2D"
+uid="uid://civ3jk3t5bai0"
+path="res://.godot/imported/edit.png-446dcdc24343dea15b1b27696f2bd4de.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/edit.png"
-dest_files=[ "res://.import/edit.png-446dcdc24343dea15b1b27696f2bd4de.stex" ]
+dest_files=["res://.godot/imported/edit.png-446dcdc24343dea15b1b27696f2bd4de.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/effects.png.import
+++ b/addons/voxel-core/assets/controls/effects.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/effects.png-cc3019a7415108bbe2cd6a01b2a05f4d.stex"
+type="StreamTexture2D"
+uid="uid://b26p4lvuh5dtx"
+path="res://.godot/imported/effects.png-cc3019a7415108bbe2cd6a01b2a05f4d.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/effects.png"
-dest_files=[ "res://.import/effects.png-cc3019a7415108bbe2cd6a01b2a05f4d.stex" ]
+dest_files=["res://.godot/imported/effects.png-cc3019a7415108bbe2cd6a01b2a05f4d.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/export.png.import
+++ b/addons/voxel-core/assets/controls/export.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/export.png-392e6dca3adf094ea5780304b67ff91b.stex"
+type="StreamTexture2D"
+uid="uid://bqr3wvthegxk7"
+path="res://.godot/imported/export.png-392e6dca3adf094ea5780304b67ff91b.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/export.png"
-dest_files=[ "res://.import/export.png-392e6dca3adf094ea5780304b67ff91b.stex" ]
+dest_files=["res://.godot/imported/export.png-392e6dca3adf094ea5780304b67ff91b.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/extrude.png.import
+++ b/addons/voxel-core/assets/controls/extrude.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/extrude.png-d6f7285b6c44effd6ac3d65b3ed32cd7.stex"
+type="StreamTexture2D"
+uid="uid://m4r22aejtfvm"
+path="res://.godot/imported/extrude.png-d6f7285b6c44effd6ac3d65b3ed32cd7.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/extrude.png"
-dest_files=[ "res://.import/extrude.png-d6f7285b6c44effd6ac3d65b3ed32cd7.stex" ]
+dest_files=["res://.godot/imported/extrude.png-d6f7285b6c44effd6ac3d65b3ed32cd7.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/fill.png.import
+++ b/addons/voxel-core/assets/controls/fill.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/fill.png-e785c5c2b1ee31f14d7d7d8a474bc3a3.stex"
+type="StreamTexture2D"
+uid="uid://7h3e0io6u4an"
+path="res://.godot/imported/fill.png-e785c5c2b1ee31f14d7d7d8a474bc3a3.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/fill.png"
-dest_files=[ "res://.import/fill.png-e785c5c2b1ee31f14d7d7d8a474bc3a3.stex" ]
+dest_files=["res://.godot/imported/fill.png-e785c5c2b1ee31f14d7d7d8a474bc3a3.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/floor.png.import
+++ b/addons/voxel-core/assets/controls/floor.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/floor.png-76f4d6848e948e1ebc4cf8e9181abea8.stex"
+type="StreamTexture2D"
+uid="uid://i2d2pi4add0t"
+path="res://.godot/imported/floor.png-76f4d6848e948e1ebc4cf8e9181abea8.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/floor.png"
-dest_files=[ "res://.import/floor.png-76f4d6848e948e1ebc4cf8e9181abea8.stex" ]
+dest_files=["res://.godot/imported/floor.png-76f4d6848e948e1ebc4cf8e9181abea8.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/general.png.import
+++ b/addons/voxel-core/assets/controls/general.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/general.png-af8f345e532cfc44e2feaf44fbb63c0b.stex"
+type="StreamTexture2D"
+uid="uid://cg0t2lb2ljw2v"
+path="res://.godot/imported/general.png-af8f345e532cfc44e2feaf44fbb63c0b.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/general.png"
-dest_files=[ "res://.import/general.png-af8f345e532cfc44e2feaf44fbb63c0b.stex" ]
+dest_files=["res://.godot/imported/general.png-af8f345e532cfc44e2feaf44fbb63c0b.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/grid.png.import
+++ b/addons/voxel-core/assets/controls/grid.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/grid.png-56b39c1518415acbf54834e0514757f3.stex"
+type="StreamTexture2D"
+uid="uid://cfno5ejewimcy"
+path="res://.godot/imported/grid.png-56b39c1518415acbf54834e0514757f3.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/grid.png"
-dest_files=[ "res://.import/grid.png-56b39c1518415acbf54834e0514757f3.stex" ]
+dest_files=["res://.godot/imported/grid.png-56b39c1518415acbf54834e0514757f3.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/import.png.import
+++ b/addons/voxel-core/assets/controls/import.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/import.png-377ecc2782d263e943001de94e25ceaf.stex"
+type="StreamTexture2D"
+uid="uid://cyf70mlet110y"
+path="res://.godot/imported/import.png-377ecc2782d263e943001de94e25ceaf.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/import.png"
-dest_files=[ "res://.import/import.png-377ecc2782d263e943001de94e25ceaf.stex" ]
+dest_files=["res://.godot/imported/import.png-377ecc2782d263e943001de94e25ceaf.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/individual.png.import
+++ b/addons/voxel-core/assets/controls/individual.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/individual.png-7b992ff172be4dc84a00cfdca92208f1.stex"
+type="StreamTexture2D"
+uid="uid://pjv2b7857h2w"
+path="res://.godot/imported/individual.png-7b992ff172be4dc84a00cfdca92208f1.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/individual.png"
-dest_files=[ "res://.import/individual.png-7b992ff172be4dc84a00cfdca92208f1.stex" ]
+dest_files=["res://.godot/imported/individual.png-7b992ff172be4dc84a00cfdca92208f1.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/info.png.import
+++ b/addons/voxel-core/assets/controls/info.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/info.png-007b0015b57716d228b0dc0ee0e10fa5.stex"
+type="StreamTexture2D"
+uid="uid://beh2vyggj7o7v"
+path="res://.godot/imported/info.png-007b0015b57716d228b0dc0ee0e10fa5.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/info.png"
-dest_files=[ "res://.import/info.png-007b0015b57716d228b0dc0ee0e10fa5.stex" ]
+dest_files=["res://.godot/imported/info.png-007b0015b57716d228b0dc0ee0e10fa5.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/issues.png.import
+++ b/addons/voxel-core/assets/controls/issues.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/issues.png-229cf0a3fbfc313cde302a402d46f7d7.stex"
+type="StreamTexture2D"
+uid="uid://c17ikrgw1y240"
+path="res://.godot/imported/issues.png-229cf0a3fbfc313cde302a402d46f7d7.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/issues.png"
-dest_files=[ "res://.import/issues.png-229cf0a3fbfc313cde302a402d46f7d7.stex" ]
+dest_files=["res://.godot/imported/issues.png-229cf0a3fbfc313cde302a402d46f7d7.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/lock.png.import
+++ b/addons/voxel-core/assets/controls/lock.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/lock.png-553809ff2d6459b74d8ba546626fed09.stex"
+type="StreamTexture2D"
+uid="uid://bc0nwm0bks0ta"
+path="res://.godot/imported/lock.png-553809ff2d6459b74d8ba546626fed09.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/lock.png"
-dest_files=[ "res://.import/lock.png-553809ff2d6459b74d8ba546626fed09.stex" ]
+dest_files=["res://.godot/imported/lock.png-553809ff2d6459b74d8ba546626fed09.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/mirrorx.png.import
+++ b/addons/voxel-core/assets/controls/mirrorx.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/mirrorx.png-572be229c3f5fcf661e2d24477316d4c.stex"
+type="StreamTexture2D"
+uid="uid://bqamosi1f6p8i"
+path="res://.godot/imported/mirrorx.png-572be229c3f5fcf661e2d24477316d4c.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/mirrorx.png"
-dest_files=[ "res://.import/mirrorx.png-572be229c3f5fcf661e2d24477316d4c.stex" ]
+dest_files=["res://.godot/imported/mirrorx.png-572be229c3f5fcf661e2d24477316d4c.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/mirrory.png.import
+++ b/addons/voxel-core/assets/controls/mirrory.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/mirrory.png-ab93caae34580c9a6038b5b2f5728acb.stex"
+type="StreamTexture2D"
+uid="uid://d23cftk5lpy5m"
+path="res://.godot/imported/mirrory.png-ab93caae34580c9a6038b5b2f5728acb.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/mirrory.png"
-dest_files=[ "res://.import/mirrory.png-ab93caae34580c9a6038b5b2f5728acb.stex" ]
+dest_files=["res://.godot/imported/mirrory.png-ab93caae34580c9a6038b5b2f5728acb.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/mirrorz.png.import
+++ b/addons/voxel-core/assets/controls/mirrorz.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/mirrorz.png-4172e70a4a19dc2827474b2090f15fae.stex"
+type="StreamTexture2D"
+uid="uid://dtd45ljb54wy5"
+path="res://.godot/imported/mirrorz.png-4172e70a4a19dc2827474b2090f15fae.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/mirrorz.png"
-dest_files=[ "res://.import/mirrorz.png-4172e70a4a19dc2827474b2090f15fae.stex" ]
+dest_files=["res://.godot/imported/mirrorz.png-4172e70a4a19dc2827474b2090f15fae.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/paint.png.import
+++ b/addons/voxel-core/assets/controls/paint.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/paint.png-a266569402af57f2f03cd276413a545e.stex"
+type="StreamTexture2D"
+uid="uid://dl8gr8mg7m5v8"
+path="res://.godot/imported/paint.png-a266569402af57f2f03cd276413a545e.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/paint.png"
-dest_files=[ "res://.import/paint.png-a266569402af57f2f03cd276413a545e.stex" ]
+dest_files=["res://.godot/imported/paint.png-a266569402af57f2f03cd276413a545e.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/pan.png.import
+++ b/addons/voxel-core/assets/controls/pan.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/pan.png-e9c7f05716b4d2bcb75e5aab794a49bd.stex"
+type="StreamTexture2D"
+uid="uid://cjlqpbbjfx2gb"
+path="res://.godot/imported/pan.png-e9c7f05716b4d2bcb75e5aab794a49bd.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/pan.png"
-dest_files=[ "res://.import/pan.png-e9c7f05716b4d2bcb75e5aab794a49bd.stex" ]
+dest_files=["res://.godot/imported/pan.png-e9c7f05716b4d2bcb75e5aab794a49bd.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/pick.png.import
+++ b/addons/voxel-core/assets/controls/pick.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/pick.png-61da8185e78416281715c2ea9bda5039.stex"
+type="StreamTexture2D"
+uid="uid://dbtk0t83gbuh5"
+path="res://.godot/imported/pick.png-61da8185e78416281715c2ea9bda5039.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/pick.png"
-dest_files=[ "res://.import/pick.png-61da8185e78416281715c2ea9bda5039.stex" ]
+dest_files=["res://.godot/imported/pick.png-61da8185e78416281715c2ea9bda5039.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/primary.png.import
+++ b/addons/voxel-core/assets/controls/primary.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/primary.png-00c953116309404e4cc7d272249267d4.stex"
+type="StreamTexture2D"
+uid="uid://6uh27pekp6ir"
+path="res://.godot/imported/primary.png-00c953116309404e4cc7d272249267d4.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/primary.png"
-dest_files=[ "res://.import/primary.png-00c953116309404e4cc7d272249267d4.stex" ]
+dest_files=["res://.godot/imported/primary.png-00c953116309404e4cc7d272249267d4.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/raw.png.import
+++ b/addons/voxel-core/assets/controls/raw.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/raw.png-d72b23a8d292660902297ee381384781.stex"
+type="StreamTexture2D"
+uid="uid://dyel60exs3euq"
+path="res://.godot/imported/raw.png-d72b23a8d292660902297ee381384781.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/raw.png"
-dest_files=[ "res://.import/raw.png-d72b23a8d292660902297ee381384781.stex" ]
+dest_files=["res://.godot/imported/raw.png-d72b23a8d292660902297ee381384781.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/refresh.png.import
+++ b/addons/voxel-core/assets/controls/refresh.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/refresh.png-34cd6fa9d7b7b01009e35226719e686b.stex"
+type="StreamTexture2D"
+uid="uid://dj1trcoail525"
+path="res://.godot/imported/refresh.png-34cd6fa9d7b7b01009e35226719e686b.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/refresh.png"
-dest_files=[ "res://.import/refresh.png-34cd6fa9d7b7b01009e35226719e686b.stex" ]
+dest_files=["res://.godot/imported/refresh.png-34cd6fa9d7b7b01009e35226719e686b.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/reset.png.import
+++ b/addons/voxel-core/assets/controls/reset.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/reset.png-87976538570a609a0c55689dc0f8cdfd.stex"
+type="StreamTexture2D"
+uid="uid://djgkby85xvqqo"
+path="res://.godot/imported/reset.png-87976538570a609a0c55689dc0f8cdfd.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/reset.png"
-dest_files=[ "res://.import/reset.png-87976538570a609a0c55689dc0f8cdfd.stex" ]
+dest_files=["res://.godot/imported/reset.png-87976538570a609a0c55689dc0f8cdfd.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/secondary.png.import
+++ b/addons/voxel-core/assets/controls/secondary.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/secondary.png-2779be8e951900e831059bca1ad87a6c.stex"
+type="StreamTexture2D"
+uid="uid://b0l0y0m12k0u7"
+path="res://.godot/imported/secondary.png-2779be8e951900e831059bca1ad87a6c.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/secondary.png"
-dest_files=[ "res://.import/secondary.png-2779be8e951900e831059bca1ad87a6c.stex" ]
+dest_files=["res://.godot/imported/secondary.png-2779be8e951900e831059bca1ad87a6c.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/select.png.import
+++ b/addons/voxel-core/assets/controls/select.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/select.png-2ecbd2be264ebb6af1d5e752108708d6.stex"
+type="StreamTexture2D"
+uid="uid://x88drx6ujto"
+path="res://.godot/imported/select.png-2ecbd2be264ebb6af1d5e752108708d6.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/select.png"
-dest_files=[ "res://.import/select.png-2ecbd2be264ebb6af1d5e752108708d6.stex" ]
+dest_files=["res://.godot/imported/select.png-2ecbd2be264ebb6af1d5e752108708d6.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/settings.png.import
+++ b/addons/voxel-core/assets/controls/settings.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/settings.png-6c842e322bdca795d6a6ca707bc85ea6.stex"
+type="StreamTexture2D"
+uid="uid://b00471yw28nwh"
+path="res://.godot/imported/settings.png-6c842e322bdca795d6a6ca707bc85ea6.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/settings.png"
-dest_files=[ "res://.import/settings.png-6c842e322bdca795d6a6ca707bc85ea6.stex" ]
+dest_files=["res://.godot/imported/settings.png-6c842e322bdca795d6a6ca707bc85ea6.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/solid.png.import
+++ b/addons/voxel-core/assets/controls/solid.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/solid.png-374b2adbc9c464a75c6ea2f0dce77290.stex"
+type="StreamTexture2D"
+uid="uid://bbpunkk2apqq"
+path="res://.godot/imported/solid.png-374b2adbc9c464a75c6ea2f0dce77290.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/solid.png"
-dest_files=[ "res://.import/solid.png-374b2adbc9c464a75c6ea2f0dce77290.stex" ]
+dest_files=["res://.godot/imported/solid.png-374b2adbc9c464a75c6ea2f0dce77290.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/sub.png.import
+++ b/addons/voxel-core/assets/controls/sub.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/sub.png-40eb99ba4394b3faa60807cda60ed1bd.stex"
+type="StreamTexture2D"
+uid="uid://cobsxk8qqjk26"
+path="res://.godot/imported/sub.png-40eb99ba4394b3faa60807cda60ed1bd.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/sub.png"
-dest_files=[ "res://.import/sub.png-40eb99ba4394b3faa60807cda60ed1bd.stex" ]
+dest_files=["res://.godot/imported/sub.png-40eb99ba4394b3faa60807cda60ed1bd.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/swap.png.import
+++ b/addons/voxel-core/assets/controls/swap.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/swap.png-7b4fb67b51c967e125a18b8652c326a8.stex"
+type="StreamTexture2D"
+uid="uid://cm6i7s1nnlibf"
+path="res://.godot/imported/swap.png-7b4fb67b51c967e125a18b8652c326a8.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/swap.png"
-dest_files=[ "res://.import/swap.png-7b4fb67b51c967e125a18b8652c326a8.stex" ]
+dest_files=["res://.godot/imported/swap.png-7b4fb67b51c967e125a18b8652c326a8.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/tools.png.import
+++ b/addons/voxel-core/assets/controls/tools.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/tools.png-028847a3d1acfbc48776b44d1bf345c4.stex"
+type="StreamTexture2D"
+uid="uid://cn7uyyvipr5sg"
+path="res://.godot/imported/tools.png-028847a3d1acfbc48776b44d1bf345c4.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/tools.png"
-dest_files=[ "res://.import/tools.png-028847a3d1acfbc48776b44d1bf345c4.stex" ]
+dest_files=["res://.godot/imported/tools.png-028847a3d1acfbc48776b44d1bf345c4.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/unlock.png.import
+++ b/addons/voxel-core/assets/controls/unlock.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/unlock.png-ddbd22687d18368c3f3e2116f87f58bc.stex"
+type="StreamTexture2D"
+uid="uid://dhhx3kfsayxxe"
+path="res://.godot/imported/unlock.png-ddbd22687d18368c3f3e2116f87f58bc.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/unlock.png"
-dest_files=[ "res://.import/unlock.png-ddbd22687d18368c3f3e2116f87f58bc.stex" ]
+dest_files=["res://.godot/imported/unlock.png-ddbd22687d18368c3f3e2116f87f58bc.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/up.png.import
+++ b/addons/voxel-core/assets/controls/up.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/up.png-872801d8cb60724f5a3cfb7b672d5a3f.stex"
+type="StreamTexture2D"
+uid="uid://c04emt3pv03ri"
+path="res://.godot/imported/up.png-872801d8cb60724f5a3cfb7b672d5a3f.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/up.png"
-dest_files=[ "res://.import/up.png-872801d8cb60724f5a3cfb7b672d5a3f.stex" ]
+dest_files=["res://.godot/imported/up.png-872801d8cb60724f5a3cfb7b672d5a3f.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/visible.png.import
+++ b/addons/voxel-core/assets/controls/visible.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/visible.png-4d489f659b102565c38b3d59c191d870.stex"
+type="StreamTexture2D"
+uid="uid://bcc4of6ilb6qd"
+path="res://.godot/imported/visible.png-4d489f659b102565c38b3d59c191d870.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/visible.png"
-dest_files=[ "res://.import/visible.png-4d489f659b102565c38b3d59c191d870.stex" ]
+dest_files=["res://.godot/imported/visible.png-4d489f659b102565c38b3d59c191d870.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/controls/wired.png.import
+++ b/addons/voxel-core/assets/controls/wired.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/wired.png-0a3b67460f74146c971e419167b3d087.stex"
+type="StreamTexture2D"
+uid="uid://d03503qy2w1is"
+path="res://.godot/imported/wired.png-0a3b67460f74146c971e419167b3d087.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/controls/wired.png"
-dest_files=[ "res://.import/wired.png-0a3b67460f74146c971e419167b3d087.stex" ]
+dest_files=["res://.godot/imported/wired.png-0a3b67460f74146c971e419167b3d087.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/logos/GitHub.png.import
+++ b/addons/voxel-core/assets/logos/GitHub.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/GitHub.png-a7e9b9a4105cbc36b63e16091f3b6653.stex"
+type="StreamTexture2D"
+uid="uid://eanpiwc8i5fv"
+path="res://.godot/imported/GitHub.png-a7e9b9a4105cbc36b63e16091f3b6653.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/logos/GitHub.png"
-dest_files=[ "res://.import/GitHub.png-a7e9b9a4105cbc36b63e16091f3b6653.stex" ]
+dest_files=["res://.godot/imported/GitHub.png-a7e9b9a4105cbc36b63e16091f3b6653.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/logos/Godot.png.import
+++ b/addons/voxel-core/assets/logos/Godot.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/Godot.png-af37480e4162bd9534f4000863edfce2.stex"
+type="StreamTexture2D"
+uid="uid://s86ogmd5nj4c"
+path="res://.godot/imported/Godot.png-af37480e4162bd9534f4000863edfce2.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/logos/Godot.png"
-dest_files=[ "res://.import/Godot.png-af37480e4162bd9534f4000863edfce2.stex" ]
+dest_files=["res://.godot/imported/Godot.png-af37480e4162bd9534f4000863edfce2.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/assets/logos/MagicaVoxel.png.import
+++ b/addons/voxel-core/assets/logos/MagicaVoxel.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/MagicaVoxel.png-30a5149067cfc4e001c354a603b78d60.stex"
+type="StreamTexture2D"
+uid="uid://dmieap77x0ia6"
+path="res://.godot/imported/MagicaVoxel.png-30a5149067cfc4e001c354a603b78d60.stex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/voxel-core/assets/logos/MagicaVoxel.png"
-dest_files=[ "res://.import/MagicaVoxel.png-30a5149067cfc4e001c354a603b78d60.stex" ]
+dest_files=["res://.godot/imported/MagicaVoxel.png-30a5149067cfc4e001c354a603b78d60.stex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+compress/streamed=false
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
+process/normal_map_invert_y=false
 process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/size_limit=0
+detect_3d/compress_to=1

--- a/addons/voxel-core/classes/reader.gd
+++ b/addons/voxel-core/classes/reader.gd
@@ -1,5 +1,5 @@
 class_name Reader
-extends Reference
+extends RefCounted
 # Makeshift interface class inhereted by all file readers.
 
 

--- a/addons/voxel-core/classes/readers/gpl.gd
+++ b/addons/voxel-core/classes/readers/gpl.gd
@@ -1,5 +1,5 @@
 class_name GPLReader
-extends Reference
+extends RefCounted
 # GIMP palette file reader
 
 

--- a/addons/voxel-core/classes/readers/image.gd
+++ b/addons/voxel-core/classes/readers/image.gd
@@ -1,5 +1,5 @@
 class_name ImageReader, "res://addons/voxel-core/assets/logos/MagicaVoxel.png"
-extends Reference
+extends RefCounted
 # Image file reader
 
 

--- a/addons/voxel-core/classes/readers/var.gd
+++ b/addons/voxel-core/classes/readers/var.gd
@@ -1,5 +1,5 @@
 class_name VarReader
-extends Reference
+extends RefCounted
 # Var file reader
 
 

--- a/addons/voxel-core/classes/voxel.gd
+++ b/addons/voxel-core/classes/voxel.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 class_name Voxel, "res://addons/voxel-core/assets/classes/voxel.png"
 extends Object
 # Utility class containing various properties and methods to do with voxels.
@@ -42,14 +42,16 @@ extends Object
 
 ## Constants
 # Lists of all voxel faces, and their adjacent directions
-const Faces := {
-	Vector3.RIGHT: [ Vector3.FORWARD, Vector3.BACK, Vector3.DOWN, Vector3.UP ],
-	Vector3.UP: [ Vector3.LEFT, Vector3.RIGHT, Vector3.FORWARD, Vector3.BACK ],
-	Vector3.FORWARD: [ Vector3.LEFT, Vector3.RIGHT, Vector3.DOWN, Vector3.UP ],
-	Vector3.LEFT: [ Vector3.FORWARD, Vector3.BACK, Vector3.DOWN, Vector3.UP ],
-	Vector3.DOWN: [ Vector3.LEFT, Vector3.RIGHT, Vector3.FORWARD, Vector3.BACK ],
-	Vector3.BACK: [ Vector3.LEFT, Vector3.RIGHT, Vector3.DOWN, Vector3.UP ],
-}
+# This is declared NOT as constant due to this 4.0 bug: https://github.com/godotengine/godot/issues/50285
+static func get_faces() -> Dictionary:
+	return {
+		Vector3.RIGHT: [ Vector3.FORWARD, Vector3.BACK, Vector3.DOWN, Vector3.UP ],
+		Vector3.UP: [ Vector3.LEFT, Vector3.RIGHT, Vector3.FORWARD, Vector3.BACK ],
+		Vector3.FORWARD: [ Vector3.LEFT, Vector3.RIGHT, Vector3.DOWN, Vector3.UP ],
+		Vector3.LEFT: [ Vector3.FORWARD, Vector3.BACK, Vector3.DOWN, Vector3.UP ],
+		Vector3.DOWN: [ Vector3.LEFT, Vector3.RIGHT, Vector3.FORWARD, Vector3.BACK ],
+		Vector3.BACK: [ Vector3.LEFT, Vector3.RIGHT, Vector3.DOWN, Vector3.UP ],
+	}
 
 
 
@@ -61,7 +63,7 @@ const Faces := {
 static func colored(color : Color, colors := {}) -> Dictionary:
 	var voxel = {}
 	voxel["color"] = color
-	if not colors.empty():
+	if not colors.is_empty():
 		voxel["colors"] = colors.duplicate()
 	return voxel
 
@@ -73,7 +75,7 @@ static func has_color(voxel : Dictionary) -> bool:
 
 # Returns the defined color within given voxel if present, otherwise returns transparent color
 static func get_color(voxel : Dictionary) -> Color:
-	return voxel.get("color", Color.transparent)
+	return voxel.get("color", Color.TRANSPARENT)
 
 
 # Sets the given color to the given voxel
@@ -111,10 +113,10 @@ static func remove_face_color(voxel : Dictionary, face : Vector3) -> void:
 # color      :   Color                          :   color to set
 # colors     :   Dictionary<Vector3, Color>     :   face colors to set
 # return     :   Dictionary<String, Variant>    :   Dictionary representing voxel
-static func uvd(uv : Vector2, uvs := {}, color := Color.white, colors := {}) -> Dictionary:
+static func uvd(uv : Vector2, uvs := {}, color := Color.WHITE, colors := {}) -> Dictionary:
 	var voxel = colored(color, colors)
 	voxel["uv"] = uv
-	if not uvs.empty():
+	if not uvs.is_empty():
 		voxel["uvs"] = uvs
 	return voxel
 
@@ -166,7 +168,7 @@ static func remove_face_uv(voxel : Dictionary, face : Vector3) -> void:
 
 # Returns true if given name is valid
 static func is_valid_name(name : String) -> bool:
-	return not name.empty()
+	return not name.is_empty()
 
 
 # Returns the defined name within given voxel if present, otherwise returns an empty string
@@ -246,7 +248,7 @@ static func remove_energy(voxel : Dictionary) -> void:
 
 # Returns the defined energy_color within given voxel if present, otherwise returns Color.white
 static func get_energy_color(voxel : Dictionary) -> Color:
-	return voxel.get("energy_color", Color.white)
+	return voxel.get("energy_color", Color.WHITE)
 
 
 # Sets the given energy_color to the given voxel
@@ -282,7 +284,7 @@ static func clean(voxel : Dictionary) -> void:
 	if get_uv(voxel) == get_uv({}):
 		remove_uv(voxel)
 	
-	for face in Faces:
+	for face in get_faces:
 		if get_face_color(voxel, face) == get_color({}):
 			remove_face_color(voxel, face)
 		if get_face_uv(voxel, face) == get_uv({}):

--- a/addons/voxel-core/classes/voxel_mesh.gd
+++ b/addons/voxel-core/classes/voxel_mesh.gd
@@ -76,38 +76,44 @@ func update_mesh() -> void:
 	if not _voxels.is_empty():
 		var vt := VoxelTool.new()
 		vt.set_voxel_size(voxel_size)
-		
 		var materials := {}
 		if is_instance_valid(mesh) and mesh is ArrayMesh:
 			for index in get_surface_override_material_count():
 				var material := get_surface_override_material(index)
 				if is_instance_valid(material):
 					materials[mesh.surface_get_name(index)] = material
-		
 		match MeshModes.NAIVE if edit_hint > 0 else mesh_mode:
 			MeshModes.GREEDY:
 				mesh = greed_volume(_voxels.keys(), vt)
 			_:
 				mesh = naive_volume(_voxels.keys(), vt)
-		
 		for material_name in materials:
 			var material_index = mesh.surface_find_by_name(material_name)
 			if material_index > -1:
 				set_surface_override_material(material_index, materials[material_name])
 	else:
+		print("Update mesh check NULL")
 		mesh = null
-	update_mesh()
+	super.update_mesh()
 
 
 func update_static_body() -> void:
+	print("Update mesh check 1")
 	var staticBody = get_node_or_null("StaticBody")
+	print(staticBody)
+	print(edit_hint)
+	print(is_instance_valid(mesh))
+	print(is_instance_valid(staticBody))
+	print("Update mesh check 2")
 	
 	if (edit_hint >= 2 or static_body) and is_instance_valid(mesh):
 		if not is_instance_valid(staticBody):
+			print("Update mesh check 3")
 			staticBody = StaticBody3D.new()
 			staticBody.set_name("StaticBody")
 			add_child(staticBody)
 		
+		print("Update mesh check 4")
 		var collisionShape
 		if staticBody.has_node("CollisionShape"):
 			collisionShape = staticBody.get_node("CollisionShape")
@@ -116,7 +122,6 @@ func update_static_body() -> void:
 			collisionShape.set_name("CollisionShape")
 			staticBody.add_child(collisionShape)
 		collisionShape.shape = mesh.create_trimesh_shape()
-		
 		if static_body and not staticBody.owner:
 			staticBody.set_owner(get_tree().get_edited_scene_root())
 		elif not static_body and staticBody.owner:
@@ -126,5 +131,7 @@ func update_static_body() -> void:
 		elif not static_body and staticBody.owner:
 			collisionShape.set_owner(null)
 	elif is_instance_valid(staticBody):
+		print("Update mesh check NULL")
 		remove_child(staticBody)
 		staticBody.queue_free()
+	print("Update mesh check FINAL")

--- a/addons/voxel-core/classes/voxel_mesh.gd
+++ b/addons/voxel-core/classes/voxel_mesh.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 class_name VoxelMesh, "res://addons/voxel-core/assets/classes/voxel_mesh.png"
 extends "res://addons/voxel-core/classes/voxel_object.gd"
 # The most basic voxel visualization object, for a moderate amount of voxels.
@@ -40,7 +40,7 @@ func _get_property_list():
 
 ## Public Methods
 func empty() -> bool:
-	return _voxels.empty()
+	return _voxels.is_empty()
 
 
 func set_voxel(grid : Vector3, voxel : int) -> void:
@@ -73,14 +73,14 @@ func erase_voxels() -> void:
 
 
 func update_mesh() -> void:
-	if not _voxels.empty():
+	if not _voxels.is_empty():
 		var vt := VoxelTool.new()
 		vt.set_voxel_size(voxel_size)
 		
 		var materials := {}
 		if is_instance_valid(mesh) and mesh is ArrayMesh:
-			for index in get_surface_material_count():
-				var material := get_surface_material(index)
+			for index in get_surface_override_material_count():
+				var material := get_surface_override_material(index)
 				if is_instance_valid(material):
 					materials[mesh.surface_get_name(index)] = material
 		
@@ -93,10 +93,10 @@ func update_mesh() -> void:
 		for material_name in materials:
 			var material_index = mesh.surface_find_by_name(material_name)
 			if material_index > -1:
-				set_surface_material(material_index, materials[material_name])
+				set_surface_override_material(material_index, materials[material_name])
 	else:
 		mesh = null
-	.update_mesh()
+	update_mesh()
 
 
 func update_static_body() -> void:
@@ -104,7 +104,7 @@ func update_static_body() -> void:
 	
 	if (edit_hint >= 2 or static_body) and is_instance_valid(mesh):
 		if not is_instance_valid(staticBody):
-			staticBody = StaticBody.new()
+			staticBody = StaticBody3D.new()
 			staticBody.set_name("StaticBody")
 			add_child(staticBody)
 		
@@ -112,7 +112,7 @@ func update_static_body() -> void:
 		if staticBody.has_node("CollisionShape"):
 			collisionShape = staticBody.get_node("CollisionShape")
 		else:
-			collisionShape = CollisionShape.new()
+			collisionShape = CollisionShape3D.new()
 			collisionShape.set_name("CollisionShape")
 			staticBody.add_child(collisionShape)
 		collisionShape.shape = mesh.create_trimesh_shape()

--- a/addons/voxel-core/classes/voxel_object.gd
+++ b/addons/voxel-core/classes/voxel_object.gd
@@ -471,9 +471,12 @@ func greed_volume(volume : Array, vt : VoxelTool = null) -> ArrayMesh:
 		for position in volume:
 			if get_voxel_id(position + face) == -1:
 				faces[face].append(position)
-	
+	# TO BE DELETED
+	var count = 0
 	for face in faces:
 		while not faces[face].is_empty():
+			count += 1
+			print(count, " done. Remaining: ", faces[face].size())
 			var bottom_right : Vector3 = faces[face].pop_front()
 			var bottom_left : Vector3 = bottom_right
 			var top_right : Vector3 = bottom_right
@@ -486,7 +489,7 @@ func greed_volume(volume : Array, vt : VoxelTool = null) -> ArrayMesh:
 				
 				while true:
 					var index = faces[face].find(top_right + Voxel.get_faces()[face][1])
-					print("Top right index", index)
+					#print("Top right index", index)
 					if index > -1:
 						var _voxel = get_voxel(faces[face][index])
 						if Voxel.get_face_color(_voxel, face) == Voxel.get_face_color(voxel, face) and (not uv_map or Voxel.get_face_uv(_voxel, face) == -Vector2.ONE):
@@ -500,7 +503,7 @@ func greed_volume(volume : Array, vt : VoxelTool = null) -> ArrayMesh:
 						break
 				
 				while true:
-					print("Top left")
+					#print("Top left")
 					var index = faces[face].find(top_left + Voxel.get_faces()[face][0])
 					if index > -1:
 						var _voxel = get_voxel(faces[face][index])
@@ -515,7 +518,7 @@ func greed_volume(volume : Array, vt : VoxelTool = null) -> ArrayMesh:
 						break
 				
 				while true:
-					print("Top right 2")
+					#print("Top right 2")
 					var used := []
 					var current := top_right
 					var index = faces[face].find(current + Voxel.get_faces()[face][3])
@@ -548,7 +551,7 @@ func greed_volume(volume : Array, vt : VoxelTool = null) -> ArrayMesh:
 						break
 				
 				while true:
-					print("Bottom right")
+					#print("Bottom right")
 					var used := []
 					var current := bottom_right
 					var index = faces[face].find(current + Voxel.get_faces()[face][2])

--- a/addons/voxel-core/classes/voxel_set.gd
+++ b/addons/voxel-core/classes/voxel_set.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 class_name VoxelSet, "res://addons/voxel-core/assets/classes/voxel_set.png"
 extends Resource
 # Library of Voxels used by VoxelObjects.
@@ -13,15 +13,28 @@ signal requested_refresh
 
 ## Exported Variables
 # Size of each tile in tiles in pixels
-export var tile_size := Vector2(32.0, 32.0) setget set_tile_size
+var _tile_size: Vector2 = Vector2(32.0, 32.0)
+@export var tile_size: Vector2:
+	get:
+		return _tile_size
+	set(value):
+		set_tile_size(value)
 
 # Texture used for tiles / uv mapping
-export var tiles : Texture = null setget set_tiles
+var _tiles: Texture = null
+@export var tiles: Texture:
+	get:
+		return _tiles
+	set(value):
+		set_tiles(value)
 
 # Materials used by voxels
-export(Array, Material) var materials := [
-	SpatialMaterial.new(),
-] setget set_materials
+var _materials: Array[Material] = [ StandardMaterial3D.new() ]
+@export var materials: Array[Material]:
+	get:
+		return _materials
+	set(value):
+		set_materials(value)
 
 
 
@@ -95,15 +108,15 @@ func set_tiles(value : Texture, refresh := true) -> void:
 func set_materials(values : Array, refresh := true) -> void:
 	for index in range(values.size()):
 		var material = values[index]
-		if is_instance_valid(material) and not (material is SpatialMaterial or material is ShaderMaterial):
+		if is_instance_valid(material) and not (material is StandardMaterial3D or material is ShaderMaterial):
 			printerr("VoxelSet : Expected Spatial or Shader material got " + str(material))
 			values[index] = null
 	
-	if values.empty():
+	if values.is_empty():
 		materials.resize(1)
 	else:
 		materials = values
-	property_list_changed_notify()
+	emit_changed()
 	
 	if refresh:
 		request_refresh()
@@ -121,7 +134,7 @@ func size() -> int:
 
 # Returns true if VoxelSet has no voxels
 func empty() -> bool:
-	return _voxels.empty()
+	return _voxels.is_empty()
 
 
 # Returns true if VoxelSet has voxel with given id
@@ -199,7 +212,7 @@ func get_voxel(id : int) -> Dictionary:
 
 # Erase voxel from VoxelSet
 func erase_voxel(id : int) -> void:
-	_voxels.remove(id)
+	_voxels.remove_at(id)
 
 
 # Erases all voxels in VoxelSet

--- a/addons/voxel-core/classes/voxel_set.gd
+++ b/addons/voxel-core/classes/voxel_set.gd
@@ -29,8 +29,8 @@ var _tiles: Texture = null
 		set_tiles(value)
 
 # Materials used by voxels
-var _materials: Array[Material] = [ StandardMaterial3D.new() ]
-@export var materials: Array[Material]:
+var _materials: Array = [ StandardMaterial3D.new() ]
+@export var materials: Array:
 	get:
 		return _materials
 	set(value):
@@ -88,7 +88,7 @@ func _get_property_list():
 ## Public Methods
 # Sets tile_size, calls on request_refresh by default
 func set_tile_size(value : Vector2, refresh := true) -> void:
-	tile_size = Vector2(
+	_tile_size = Vector2(
 			floor(clamp(value.x, 1, 256)),
 			floor(clamp(value.y, 1, 256)))
 	
@@ -98,7 +98,7 @@ func set_tile_size(value : Vector2, refresh := true) -> void:
 
 # Sets tiles, calls on request_refresh by default
 func set_tiles(value : Texture, refresh := true) -> void:
-	tiles = value
+	_tiles = value
 	
 	if refresh:
 		request_refresh()
@@ -113,9 +113,9 @@ func set_materials(values : Array, refresh := true) -> void:
 			values[index] = null
 	
 	if values.is_empty():
-		materials.resize(1)
+		_materials.resize(1)
 	else:
-		materials = values
+		_materials = values
 	emit_changed()
 	
 	if refresh:

--- a/addons/voxel-core/classes/voxel_tool.gd
+++ b/addons/voxel-core/classes/voxel_tool.gd
@@ -136,87 +136,87 @@ func add_face(
 		
 		_surfaces[surface_id] = surface
 	
-	surface.surface_tool.add_normal(face)
-	surface.surface_tool.add_color(color)
+	surface.surface_tool.set_normal(face)
+	surface.surface_tool.set_color(color)
 	
 	match face:
 		Vector3.RIGHT:
 			if uv_surface:
-				surface.surface_tool.add_uv((uv + Vector2.RIGHT) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv + Vector2.RIGHT) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((top_left + Vector3.RIGHT + Vector3.UP) * _voxel_size)
 			if uv_surface:
-				surface.surface_tool.add_uv((uv + Vector2.ONE) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv + Vector2.ONE) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((bottom_left + Vector3.RIGHT) * _voxel_size)
 			if uv_surface:
-				surface.surface_tool.add_uv((uv) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((top_right + Vector3.ONE) * _voxel_size)
 			if uv_surface:
-				surface.surface_tool.add_uv((uv + Vector2.DOWN) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv + Vector2.DOWN) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((bottom_right + Vector3.RIGHT + Vector3.BACK) * _voxel_size)
 		Vector3.LEFT:
 			if uv_surface:
-				surface.surface_tool.add_uv((uv + Vector2.DOWN) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv + Vector2.DOWN) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((bottom_left) * _voxel_size)
 			if uv_surface:
-				surface.surface_tool.add_uv((uv) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((top_left + Vector3.UP) * _voxel_size)
 			if uv_surface:
-				surface.surface_tool.add_uv((uv + Vector2.ONE) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv + Vector2.ONE) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((bottom_right + Vector3.BACK) * _voxel_size)
 			if uv_surface:
-				surface.surface_tool.add_uv((uv + Vector2.RIGHT) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv + Vector2.RIGHT) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((top_right + Vector3.UP + Vector3.BACK) * _voxel_size)
 		Vector3.UP:
 			if uv_surface:
-				surface.surface_tool.add_uv((uv + Vector2.DOWN) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv + Vector2.DOWN) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((top_left + Vector3.UP + Vector3.BACK) *_voxel_size)
 			if uv_surface:
-				surface.surface_tool.add_uv((uv) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((bottom_left + Vector3.UP) * _voxel_size)
 			if uv_surface:
-				surface.surface_tool.add_uv((uv + Vector2.ONE) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv + Vector2.ONE) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((top_right + Vector3.ONE) * _voxel_size)
 			if uv_surface:
-				surface.surface_tool.add_uv((uv + Vector2.RIGHT) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv + Vector2.RIGHT) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((bottom_right + Vector3.RIGHT + Vector3.UP) * _voxel_size)
 		Vector3.DOWN:
 			if uv_surface:
-				surface.surface_tool.add_uv((uv + Vector2.DOWN) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv + Vector2.DOWN) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((top_right + Vector3.RIGHT + Vector3.BACK) * _voxel_size)
 			if uv_surface:
-				surface.surface_tool.add_uv((uv) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((bottom_right + Vector3.RIGHT) * _voxel_size)
 			if uv_surface:
-				surface.surface_tool.add_uv((uv + Vector2.ONE) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv + Vector2.ONE) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((top_left + Vector3.BACK) * _voxel_size)
 			if uv_surface:
-				surface.surface_tool.add_uv((uv + Vector2.RIGHT) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv + Vector2.RIGHT) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((bottom_left) * _voxel_size)
 		Vector3.FORWARD:
 			if uv_surface:
-				surface.surface_tool.add_uv((uv + Vector2.ONE) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv + Vector2.ONE) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((bottom_right + Vector3.RIGHT) * _voxel_size)
 			if uv_surface:
-				surface.surface_tool.add_uv((uv + Vector2.RIGHT) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv + Vector2.RIGHT) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((top_right + Vector3.RIGHT + Vector3.UP) * _voxel_size)
 			if uv_surface:
-				surface.surface_tool.add_uv((uv + Vector2.DOWN) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv + Vector2.DOWN) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((bottom_left) * _voxel_size)
 			if uv_surface:
-				surface.surface_tool.add_uv((uv) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((top_left + Vector3.UP) * _voxel_size)
 		Vector3.BACK:
 			if uv_surface:
-				surface.surface_tool.add_uv((uv + Vector2.RIGHT) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv + Vector2.RIGHT) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((top_right + Vector3.ONE) * _voxel_size)
 			if uv_surface:
-				surface.surface_tool.add_uv((uv + Vector2.ONE) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv + Vector2.ONE) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((bottom_right + Vector3.RIGHT + Vector3.BACK) * _voxel_size)
 			if uv_surface:
-				surface.surface_tool.add_uv((uv) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((top_left + Vector3.UP + Vector3.BACK) * _voxel_size)
 			if uv_surface:
-				surface.surface_tool.add_uv((uv + Vector2.DOWN) * _voxel_set.uv_scale())
+				surface.surface_tool.set_uv((uv + Vector2.DOWN) * _voxel_set.uv_scale())
 			surface.surface_tool.add_vertex((bottom_left + Vector3.BACK) * _voxel_size)
 	
 	surface.index += 4
@@ -232,5 +232,5 @@ func add_face(
 # voxel   :   Dictioanry<String, Variant>   :   voxel data to use
 # grid    :   Vector3                       :   voxel grid position of voxel
 func add_faces(voxel : Dictionary, grid : Vector3) -> void:
-	for face in Voxel.Faces:
+	for face in Voxel.get_faces():
 		add_face(voxel, face, grid)

--- a/addons/voxel-core/classes/voxel_tool.gd
+++ b/addons/voxel-core/classes/voxel_tool.gd
@@ -1,6 +1,6 @@
-tool
+@tool
 class_name VoxelTool
-extends Reference
+extends RefCounted
 # Used to construct a Mesh with provided VoxelSet 
 # and by specifying voxel faces individually.
 
@@ -11,7 +11,7 @@ class Surface:
 	# Index of the last vertex in Mesh being constructed
 	var index : int
 	
-	var material : SpatialMaterial
+	var material : StandardMaterial3D
 	
 	# SurfaceTool used to construct Mesh
 	var surface_tool : SurfaceTool
@@ -87,13 +87,13 @@ func add_face(
 		voxel : Dictionary,
 		face : Vector3,
 		bottom_right : Vector3,
-		bottom_left := Vector3.INF,
-		top_right := Vector3.INF,
-		top_left := Vector3.INF) -> void:
+		bottom_left := Vector3(INF, INF, INF),
+		top_right := Vector3(INF, INF, INF),
+		top_left := Vector3(INF, INF, INF)) -> void:
 	bottom_right = bottom_right
-	if bottom_left == Vector3.INF: bottom_left = bottom_right
-	if top_right == Vector3.INF: top_right = bottom_right
-	if top_left == Vector3.INF: top_left = bottom_right
+	if bottom_left == Vector3(INF, INF, INF): bottom_left = bottom_right
+	if top_right == Vector3(INF, INF, INF): top_right = bottom_right
+	if top_left == Vector3(INF, INF, INF): top_left = bottom_right
 	
 	var color := Voxel.get_face_color(voxel, face)
 	var uv := Voxel.get_face_uv(voxel, face) if _uv_voxels else -Vector2.ONE
@@ -118,7 +118,7 @@ func add_face(
 		if is_instance_valid(surface.material):
 			surface.material = surface.material.duplicate()
 		else:
-			surface.material = SpatialMaterial.new()
+			surface.material = StandardMaterial3D.new()
 			
 			surface.material.metallic = metal
 			surface.material.metallic_specular = specular
@@ -128,7 +128,7 @@ func add_face(
 				surface.material.emission = energy_color
 				surface.material.emission_energy = energy
 		
-		if surface.material is SpatialMaterial:
+		if surface.material is StandardMaterial3D:
 			surface.material.vertex_color_use_as_albedo = true
 			surface.material.vertex_color_is_srgb = true
 			if uv_surface:

--- a/addons/voxel-core/controls/menus/color_picker_menu/color_picker_menu.gd
+++ b/addons/voxel-core/controls/menus/color_picker_menu/color_picker_menu.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends "res://addons/voxel-core/controls/menus/menu.gd"
 ## Color Picker Menu Class
 
@@ -12,28 +12,63 @@ signal color_picked(color)
 
 
 ## Exported Variables
-export var color : Color = Color.white setget set_color
+var _color: Color = Color.WHITE
+@export var color: Color:
+	get:
+		return _color
+	set(value):
+		set_color(value)
 
-export var edit_alpha : bool = true setget set_edit_alpha
+var _edit_alpha: bool = true
+@export var edit_alpha: bool:
+	get:
+		return _edit_alpha
+	set(value):
+		set_edit_alpha(value)
 
-export var hsv_mode : bool = false setget set_hsv_mode
+var _hsv_mode: bool = false
+@export var hsv_mode: bool:
+	get:
+		return _hsv_mode
+	set(value):
+		set_hsv_mode(value)
 
-export var raw_mode : bool = false setget set_raw_mode
+var _raw_mode: bool = false
+@export var raw_mode: bool:
+	get:
+		return _raw_mode
+	set(value):
+		set_raw_mode(value)
 
-export var deferred_mode : bool = false setget set_deferred_mode
+var _deferred_mode: bool = false
+@export var deferred_mode: bool:
+	get:
+		return _deferred_mode
+	set(value):
+		set_deferred_mode(value)
 
-export var presets_enabled : bool = true setget set_presets_enabled
+var _presets_enabled: bool = true
+@export var presets_enabled: bool:
+	get:
+		return _presets_enabled
+	set(value):
+		set_presets_enabled(value)
 
-export var presets_visible : bool = true setget set_presets_visible
+var _presets_visible: bool = true
+@export var presets_visible: bool:
+	get:
+		return _presets_visible
+	set(value):
+		set_presets_visible(value)
 
 
 
 ## OnReady Variables
-onready var color_picker : ColorPicker = get_node("VBoxContainer/ColorPicker")
+@onready var color_picker : ColorPicker = get_node("VBoxContainer/ColorPicker")
 
-onready var confirm : Button = get_node("VBoxContainer/HBoxContainer/Confirm")
+@onready var confirm : Button = get_node("VBoxContainer/HBoxContainer/Confirm")
 
-onready var cancel : Button = get_node("VBoxContainer/HBoxContainer/Cancel")
+@onready var cancel : Button = get_node("VBoxContainer/HBoxContainer/Cancel")
 
 
 
@@ -49,53 +84,53 @@ func _ready() -> void:
 	
 	update_rect_min()
 	
-	color_picker.connect("color_changed", self, "_on_ColorPicker_color_changed")
+	color_picker.connect("color_changed", _on_ColorPicker_color_changed)
 	
-	confirm.connect("pressed", self, "_on_Confirm_pressed")
+	confirm.connect("pressed", _on_Confirm_pressed)
 	
-	cancel.connect("pressed", self, "_on_Cancel_pressed")
+	cancel.connect("pressed", _on_Cancel_pressed)
 
 
 
 ## Public Methods
 func set_color(value : Color) -> void:
-	color = value
+	_color = value
 	if is_instance_valid(color_picker):
 		color_picker.color = color
 
 
 func set_edit_alpha(value : bool) -> void:
-	edit_alpha = value
+	_edit_alpha = value
 	if is_instance_valid(color_picker):
 		color_picker.edit_alpha = edit_alpha
 
 
 func set_hsv_mode(value : bool) -> void:
-	hsv_mode = value
+	_hsv_mode = value
 	if is_instance_valid(color_picker):
 		color_picker.hsv_mode = hsv_mode
 
 
 func set_raw_mode(value : bool) -> void:
-	raw_mode = value
+	_raw_mode = value
 	if is_instance_valid(color_picker):
 		color_picker.raw_mode = raw_mode
 
 
 func set_deferred_mode(value : bool) -> void:
-	deferred_mode = value
+	_deferred_mode = value
 	if is_instance_valid(color_picker):
 		color_picker.deferred_mode = deferred_mode
 
 
 func set_presets_enabled(value : bool) -> void:
-	presets_enabled = value
+	_presets_enabled = value
 	if is_instance_valid(color_picker):
 		color_picker.presets_enabled = presets_enabled
 
 
 func set_presets_visible(value : bool) -> void:
-	presets_visible = value
+	_presets_visible = value
 	if is_instance_valid(color_picker):
 		color_picker.presets_visible = presets_visible
 

--- a/addons/voxel-core/controls/menus/material_picker_menu/material_picker_menu.gd
+++ b/addons/voxel-core/controls/menus/material_picker_menu/material_picker_menu.gd
@@ -1,4 +1,4 @@
-extends WindowDialog
+extends PopupMenu
 
 
 # Declare member variables here. Examples:

--- a/addons/voxel-core/controls/menus/menu.gd
+++ b/addons/voxel-core/controls/menus/menu.gd
@@ -1,38 +1,38 @@
-tool
-extends WindowDialog
+@tool
+extends PopupMenu
 ## Menu Class
 
 
 
 ## Exported Variables
-export var keep_centered := true
+@export var keep_centered := true
 
 
 
 ## Built-In Virtual Methods
 func _ready() -> void:
-	get_tree().connect("screen_resized", self, "_on_SceneTree_screen_resized")
+	get_tree().connect("screen_resized", _on_SceneTree_screen_resized)
 
 
 
 ## Public Methods
 func update_rect_min() -> void:
-	rect_min_size = Vector2.ZERO
-	set_as_minsize()
-	rect_size += Vector2(32, 32)
-	rect_min_size = rect_size
+	min_size = Vector2.ZERO
+	size = min_size
+	size += Vector2i(32, 32)
+	min_size = size
 
 
 func show_centered() -> void:
 	update_rect_min()
 	set_position(
-			(get_viewport_rect().size / 2) - (rect_min_size / 2))
+			(Vector2i(get_visible_rect().size / 2)) - (min_size / 2))
 	show()
 
 
 func popup_centered(size : Vector2 = Vector2( 0, 0 )) -> void:
 	update_rect_min()
-	.popup_centered(size)
+	super.popup_centered(size)
 
 
 

--- a/addons/voxel-core/controls/menus/tile_picker_menu/tile_picker_menu.gd
+++ b/addons/voxel-core/controls/menus/tile_picker_menu/tile_picker_menu.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends "res://addons/voxel-core/controls/menus/menu.gd"
 ## Color Picker Menu Class
 
@@ -14,24 +14,50 @@ signal tile_picked(tiles)
 
 
 ## Exported Variables
-export(int, -1, 256) var selection_max := 0 setget set_selection_max
+# Range temporarily disabled for 4.0
+var _selection_max: int = 10
+@export var selection_max: int:
+	get:
+		return _selection_max
+	set(value):
+		set_selection_max(value)
 
-export var hovered_color := Color(1, 1, 1, 0.6) setget set_hovered_color
+var _hovered_color: Color = Color(1, 1, 1, 0.6)
+@export var hovered_color: Color:
+	get:
+		return _hovered_color
+	set(value):
+		set_hovered_color(value)
 
-export var selected_color := Color.white setget set_selection_color
+var _selected_color: Color = Color.WHITE
+@export var selected_color: Color:
+	get:
+		return _selected_color
+	set(value):
+		set_selection_color(value)
 
-export var invalid_color := Color.red setget set_invalid_color
+var _invalid_color: Color = Color.RED
+@export var invalid_color: Color:
+	get:
+		return _invalid_color
+	set(value):
+		set_invalid_color(value)
 
-export(Resource) var voxel_set setget set_voxel_set
+var _voxel_set: Resource
+@export var voxel_set: Resource:
+	get:
+		return _voxel_set
+	set(value):
+		set_voxel_set(value)
 
 
 
 ## OnReady Variables
-onready var tiles_viewer := get_node("VBoxContainer/ScrollContainer/TilesViewer")
+@onready var tiles_viewer := get_node("VBoxContainer/ScrollContainer/TilesViewer")
 
-onready var confirm : Button = get_node("VBoxContainer/HBoxContainer/Confirm")
+@onready var confirm : Button = get_node("VBoxContainer/HBoxContainer/Confirm")
 
-onready var cancel : Button = get_node("VBoxContainer/HBoxContainer/Cancel")
+@onready var cancel : Button = get_node("VBoxContainer/HBoxContainer/Cancel")
 
 
 
@@ -45,41 +71,41 @@ func _ready() -> void:
 	
 	update_rect_min()
 	
-	tiles_viewer.connect("tile_selected", self, "_on_TilesViewer_selected_tile")
-	tiles_viewer.connect("tile_unselected", self, "_on_TilesViewer_unselected_tile")
+	tiles_viewer.connect("tile_selected", _on_TilesViewer_selected_tile)
+	tiles_viewer.connect("tile_unselected", _on_TilesViewer_unselected_tile)
 	
-	confirm.connect("pressed", self, "_on_Confirm_pressed")
+	confirm.connect("pressed", _on_Confirm_pressed)
 	
-	cancel.connect("pressed", self, "_on_Cancel_pressed")
+	cancel.connect("pressed", _on_Cancel_pressed)
 
 
 ## Public Methods
 func set_selection_max(value : int, update := true) -> void:
-	selection_max = value
+	_selection_max = value
 	if is_instance_valid(tiles_viewer):
 		tiles_viewer.set_selection_max(value, update)
 
 
 func set_hovered_color(value : Color, update := true) -> void:
-	hovered_color = value
+	_hovered_color = value
 	if is_instance_valid(tiles_viewer):
 		tiles_viewer.set_hovered_color(value, update)
 
 
 func set_selection_color(value : Color, update := true) -> void:
-	selected_color = value
+	_selected_color = value
 	if is_instance_valid(tiles_viewer):
 		tiles_viewer.set_selection_color(value, update)
 
 
 func set_invalid_color(value : Color, update := true) -> void:
-	invalid_color = value
+	_invalid_color = value
 	if is_instance_valid(tiles_viewer):
 		tiles_viewer.set_invalid_color(value, update)
 
 
 func set_voxel_set(value : Resource, update := true) -> void:
-	voxel_set = value
+	_voxel_set = value
 	if is_instance_valid(tiles_viewer):
 		tiles_viewer.set_voxel_set(value, update)
 

--- a/addons/voxel-core/controls/tiles_viewer/tiles_viewer.gd
+++ b/addons/voxel-core/controls/tiles_viewer/tiles_viewer.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends TextureRect
 # Shows tiles of VoxelSet and allows for the selection of Tile(s)
 
@@ -14,19 +14,45 @@ signal unselected_uv(uv)
 
 ## Exported Variables
 # Maximum number of uv positions that can be selected at any one time
-export(int, -1, 256) var selection_max := 0 setget set_selection_max
+# Range disabled because of bug in GDScript 2
+var _selection_max: int = 0
+@export var selection_max: int:
+	get:
+		return _selection_max
+	set(value):
+		set_selection_max(value)
 
 # Color to applyed to border of hovered uv position(s)
-export var hovered_color := Color(1, 1, 1, 0.6) setget set_hovered_color
+var _hovered_color: Color = Color(1, 1, 1, 0.6)
+@export var hovered_color: Color:
+	get:
+		return _hovered_color
+	set(value):
+		set_hovered_color(value)
 
 # Color to applyed to border of selected uv position(s)
-export var selected_color := Color.white setget set_selection_color
+var _selected_color: Color = Color.WHITE
+@export var selected_color: Color:
+	get:
+		return _selected_color
+	set(value):
+		set_selection_color(value)
 
 # Color to applyed to border of invalid uv position(s)
-export var invalid_color := Color.red setget set_invalid_color
+var _invalid_color: Color = Color.RED
+@export var invalid_color: Color:
+	get:
+		return _invalid_color
+	set(value):
+		set_invalid_color(value)
 
 # VoxelSet being used
-export(Resource) var voxel_set = null setget set_voxel_set
+var _voxel_set: Resource = null
+@export var voxel_set: Resource:
+	get:
+		return _voxel_set
+	set(value):
+		set_voxel_set(value)
 
 
 
@@ -44,7 +70,7 @@ func _gui_input(event : InputEvent):
 	if event is InputEventMouse:
 		_last_uv_hovered = world_to_uv(event.position)
 		if selection_max != 0 and event is InputEventMouseButton:
-			if is_valid_uv(_last_uv_hovered) and event.button_index == BUTTON_LEFT and not event.is_pressed():
+			if is_valid_uv(_last_uv_hovered) and event.button_index == MOUSE_BUTTON_LEFT and not event.is_pressed():
 				if _selections.has(_last_uv_hovered):
 					unselect(_last_uv_hovered)
 				else:
@@ -105,21 +131,21 @@ func set_invalid_color(value : Color, update := true) -> void:
 
 
 # Sets voxel_set, calls update_mesh if needed and not told otherwise
-func set_voxel_set(value : Resource, update := true) -> void:
+func set_voxel_set(value : Resource, update_mesh := true) -> void:
 	if not (typeof(value) == TYPE_NIL or value is VoxelSet):
 		printerr("Invalid Resource given expected VoxelSet")
 		return
 	
 	if is_instance_valid(voxel_set):
-		if voxel_set.is_connected("requested_refresh", self, "update"):
-			voxel_set.disconnect("requested_refresh", self, "update")
+		if voxel_set.is_connected("requested_refresh", update):
+			voxel_set.disconnect("requested_refresh", update)
 	
 	voxel_set = value
 	if is_instance_valid(voxel_set):
-		if not voxel_set.is_connected("requested_refresh", self, "update"):
-			voxel_set.connect("requested_refresh", self, "update")
+		if not voxel_set.is_connected("requested_refresh", update):
+			voxel_set.connect("requested_refresh", update)
 	
-	if update:
+	if update_mesh:
 		self.update()
 
 
@@ -181,7 +207,7 @@ func unselect(uv : Vector2, emit := true) -> void:
 
 # Unselects all uv position
 func unselect_all() -> void:
-	while not _selections.empty():
+	while not _selections.is_empty():
 		unselect(_selections.back())
 
 

--- a/addons/voxel-core/controls/tiles_viewer/tiles_viewer.gd
+++ b/addons/voxel-core/controls/tiles_viewer/tiles_viewer.gd
@@ -68,7 +68,7 @@ var _selections := []
 
 ## Built-In Virtual Methods
 func _ready() -> void:
-	connect("mouse_exited", self, "_on_mouse_exited")
+	connect("mouse_exited", _on_mouse_exited)
 
 
 func _gui_input(event : InputEvent):

--- a/addons/voxel-core/controls/tiles_viewer/tiles_viewer.gd
+++ b/addons/voxel-core/controls/tiles_viewer/tiles_viewer.gd
@@ -103,7 +103,7 @@ func _draw():
 ## Public Methods
 # Sets selection_max, shrinks _selections to new maximum if needed and calls on update by default
 func set_selection_max(value : int, update := true) -> void:
-	selection_max = clamp(value, -1, 256)
+	_selection_max = clamp(value, -1, 256)
 	unselect_shrink()
 	if update:
 		self.update()
@@ -111,21 +111,21 @@ func set_selection_max(value : int, update := true) -> void:
 
 # Sets hovered_color, and calls on update by default
 func set_hovered_color(value : Color, update := true) -> void:
-	hovered_color = value
+	_hovered_color = value
 	if update:
 		self.update()
 
 
 # Sets selected_color, and calls on update by default
 func set_selection_color(value : Color, update := true) -> void:
-	selected_color = value
+	_selected_color = value
 	if update:
 		self.update()
 
 
 # Sets invalid_color, and calls on update by default
 func set_invalid_color(value : Color, update := true) -> void:
-	invalid_color = value
+	_invalid_color = value
 	if update:
 		self.update()
 
@@ -138,12 +138,12 @@ func set_voxel_set(value : Resource, update_mesh := true) -> void:
 	
 	if is_instance_valid(voxel_set):
 		if voxel_set.is_connected("requested_refresh", update):
-			voxel_set.disconnect("requested_refresh", update)
+			_voxel_set.disconnect("requested_refresh", update)
 	
 	voxel_set = value
 	if is_instance_valid(voxel_set):
 		if not voxel_set.is_connected("requested_refresh", update):
-			voxel_set.connect("requested_refresh", update)
+			_voxel_set.connect("requested_refresh", update)
 	
 	if update_mesh:
 		self.update()

--- a/addons/voxel-core/controls/voxel_button/voxel_button.gd
+++ b/addons/voxel-core/controls/voxel_button/voxel_button.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends Button
 # Button representing a voxel's face
 
@@ -6,19 +6,45 @@ extends Button
 
 ## Exported Variables
 # Color of voxel
-export var voxel_color := Color.black setget set_voxel_color
+var _voxel_color: Color = Color.BLACK
+@export var voxel_color: Color:
+	get:
+		return _voxel_color
+	set(value):
+		set_voxel_color(value)
 
 # Texture of voxel
-export var voxel_texture : Texture = null setget set_voxel_texture
+var _voxel_texture: Texture = null
+@export var voxel_texture: Texture:
+	get:
+		return _voxel_texture
+	set(value):
+		set_voxel_texture(value)
 
 # ID of voxel to represented
-export(int, -1, 100000) var voxel_id := -1 setget set_voxel_id
+# Range disabled due to GDScript 2 bug
+var _voxel_id: int = -1
+@export var voxel_id: int:
+	get:
+		return _voxel_id
+	set(value):
+		set_voxel_id(value)
 
 # Voxel's face to represent
-export var voxel_face := Vector3.ZERO setget set_voxel_face
+var _voxel_face: Vector3 = Vector3.ZERO
+@export var voxel_face: Vector3:
+	get:
+		return _voxel_face
+	set(value):
+		set_voxel_face(value)
 
 # VoxelSet being used
-export(Resource) var voxel_set = null setget set_voxel_set
+var _voxel_set: Resource = null
+@export var voxel_set: Resource:
+	get:
+		return _voxel_set
+	set(value):
+		set_voxel_set(value)
 
 
 
@@ -35,7 +61,7 @@ func set_voxel_color(value : Color) -> void:
 	voxel_color = value
 	
 	$VoxelColor.color = voxel_color
-	property_list_changed_notify()
+	$VoxelColor.emit_changed()
 
 
 # Sets voxel_texture
@@ -43,7 +69,7 @@ func set_voxel_texture(value : Texture) -> void:
 	voxel_texture = value
 	
 	$VoxelColor/VoxelTexture.texture = voxel_texture
-	property_list_changed_notify()
+	$VoxelColor/VoxelTexture.emit_changed()
 
 
 # Sets voxel_id, and calls on update_view by default

--- a/addons/voxel-core/controls/voxel_button/voxel_button.gd
+++ b/addons/voxel-core/controls/voxel_button/voxel_button.gd
@@ -58,7 +58,7 @@ func _ready():
 ## Public Methods
 # Sets voxel_color
 func set_voxel_color(value : Color) -> void:
-	voxel_color = value
+	_voxel_color = value
 	
 	$VoxelColor.color = voxel_color
 	$VoxelColor.emit_changed()
@@ -66,7 +66,7 @@ func set_voxel_color(value : Color) -> void:
 
 # Sets voxel_texture
 func set_voxel_texture(value : Texture) -> void:
-	voxel_texture = value
+	_voxel_texture = value
 	
 	$VoxelColor/VoxelTexture.texture = voxel_texture
 	$VoxelColor/VoxelTexture.emit_changed()
@@ -77,7 +77,7 @@ func set_voxel_id(value : int, update := true) -> void:
 	if value < -1:
 		return
 	
-	voxel_id = value
+	_voxel_id = value
 	
 	if update:
 		update_view()
@@ -85,7 +85,7 @@ func set_voxel_id(value : int, update := true) -> void:
 
 # Sets voxel_face, and calls on update_view by default
 func set_voxel_face(value : Vector3, update := true) -> void:
-	voxel_face = value
+	_voxel_face = value
 	if update:
 		update_view()
 
@@ -96,7 +96,7 @@ func set_voxel_set(value : Resource, update := true) -> void:
 		printerr("Invalid Resource given expected VoxelSet")
 		return
 	
-	voxel_set = value
+	_voxel_set = value
 	if update:
 		update_view()
 

--- a/addons/voxel-core/controls/voxel_set_viewer/voxel_set_viewer.gd
+++ b/addons/voxel-core/controls/voxel_set_viewer/voxel_set_viewer.gd
@@ -99,7 +99,7 @@ func _ready():
 ## Public Methods
 # Sets search, and calls on update_view by default
 func set_search(value : String, update := true) -> void:
-	search = value
+	_search = value
 	
 	if is_instance_valid(Search):
 		Search.text = search
@@ -109,18 +109,18 @@ func set_search(value : String, update := true) -> void:
 
 # Sets allow_edit
 func set_edit_mode(value : bool, update := true) -> void:
-	allow_edit = value
+	_allow_edit = value
 
 
 # Sets selection_max, and shrinks _selections to new maximum if needed
 func set_selection_max(value : int) -> void:
-	selection_max = clamp(value, -1, 256)
+	_selection_max = clamp(value, -1, 256)
 	unselect_shrink()
 
 
 # Setter for show_hints
 func set_show_hints(value := show_hints) -> void:
-	show_hints = value
+	_show_hints = value
 	
 	if is_instance_valid(Hints):
 		Hints.visible = show_hints and (allow_edit or selection_max)
@@ -140,9 +140,9 @@ func set_voxel_set(value : Resource, update := true) -> void:
 	
 	if is_instance_valid(voxel_set):
 		if voxel_set.is_connected("requested_refresh", update_view):
-			voxel_set.disconnect("requested_refresh", update_view) 
+			_voxel_set.disconnect("requested_refresh", update_view) 
 	
-	voxel_set = value
+	_voxel_set = value
 	if is_instance_valid(voxel_set):
 		if not voxel_set.is_connected("requested_refresh", update_view):
 			voxel_set.connect("requested_refresh", update_view, [true])

--- a/addons/voxel-core/controls/voxel_viewer/voxel_viewer.gd
+++ b/addons/voxel-core/controls/voxel_viewer/voxel_viewer.gd
@@ -224,7 +224,7 @@ func reset_environment() -> void:
 
 
 func set_selection_max(value : int, update := true) -> void:
-	selection_max = clamp(value, 0, 6)
+	_selection_max = clamp(value, 0, 6)
 	unselect_shrink()
 	if update:
 		self.update()
@@ -232,13 +232,13 @@ func set_selection_max(value : int, update := true) -> void:
 
 # Sets allow_edit
 func set_allow_edit(value : bool) -> void:
-	allow_edit = value
+	_allow_edit = value
 
 
 # Sets view_mode
 func set_view_mode(value : int) -> void:
 	_last_hovered_face = Vector3.ZERO
-	view_mode = int(clamp(value, 0, ViewModes.size()))
+	_view_mode = int(clamp(value, 0, ViewModes.size()))
 	
 	if is_instance_valid(ViewModeRef):
 		ViewModeRef.selected = view_mode
@@ -250,7 +250,7 @@ func set_view_mode(value : int) -> void:
 
 # Sets voxel_id, calls on update_view by defalut
 func set_voxel_id(value : int, update := true) -> void:
-	voxel_id = value
+	_voxel_id = value
 	if update:
 		update_view()
 
@@ -283,9 +283,9 @@ func set_voxel_set(value : Resource, update := true) -> void:
 	
 	if is_instance_valid(voxel_set):
 		if voxel_set.is_connected("requested_refresh", update_view):
-			voxel_set.disconnect("requested_refresh", update_view) 
+			_voxel_set.disconnect("requested_refresh", update_view) 
 	
-	voxel_set = value
+	_voxel_set = value
 	if is_instance_valid(voxel_set):
 		if not voxel_set.is_connected("requested_refresh", update_view):
 			voxel_set.connect("requested_refresh", update_view)
@@ -297,7 +297,7 @@ func set_voxel_set(value : Resource, update := true) -> void:
 
 
 func set_environment(value : Environment) -> void:
-	environment = value
+	_environment = value
 	if is_instance_valid(ViewPort):
 		ViewPort.transparent_bg = environment == DefaultEnv
 		ViewPort.world.environment = environment

--- a/addons/voxel-core/controls/voxel_viewer/voxel_viewer.gd
+++ b/addons/voxel-core/controls/voxel_viewer/voxel_viewer.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends Control
 # 2D / 3D preview of a voxel, that allows for selection and editing of faces.
 
@@ -26,25 +26,63 @@ var DefaultEnv := preload("res://addons/voxel-core/controls/voxel_viewer/voxel_v
 
 ## Exported Variables
 # Number of uv positions that can be selected at any one time
-export(int, 0, 6) var selection_max := 0 setget set_selection_max
+# Range disabled because of bug in GDScript 2
+var _selection_max: int = 0
+@export var selection_max: int:
+	get:
+		return _selection_max
+	set(value):
+		set_selection_max(value)
 
 # Flag indicating whether edits are allowed
-export var allow_edit := false setget set_allow_edit
+var _allow_edit: bool = false
+@export var allow_edit: bool:
+	get:
+		return _allow_edit
+	set(value):
+		set_allow_edit(value)
 
 # Current view being shown
-export(ViewModes) var view_mode := ViewModes.VIEW_3D setget set_view_mode
+var _view_mode: ViewModes = ViewModes.VIEW_3D
+@export var view_mode: ViewModes:
+	get:
+		return _view_mode
+	set(value):
+		set_view_mode(value)
 
 # View sensitivity for the 3D view
-export(int, 0, 100) var camera_sensitivity := 8
+var _camera_sensitivity: int = 8
+@export_range(1, 100) var camera_sensitivity: int:
+	get:
+		return _camera_sensitivity
+	set(value):
+		_camera_sensitivity = value
 
 # ID of voxel to represented
-export var voxel_id : int setget set_voxel_id
+# Range disabled due to GDScript 2 bug
+var _voxel_id: int = 0
+@export var voxel_id: int:
+	get:
+		return _voxel_id
+	set(value):
+		set_voxel_id(value)
 
 # VoxelSet beings used
-export(Resource) var voxel_set = null setget set_voxel_set
+# VoxelSet being used
+var _voxel_set: Resource = null
+@export var voxel_set: Resource:
+	get:
+		return _voxel_set
+	set(value):
+		set_voxel_set(value)
 
 # Environment used in 3D view
-export(Environment) var environment := DefaultEnv setget set_environment
+var _environment: Environment = DefaultEnv
+@export var environment: Environment:
+	get:
+		return _environment
+	set(value):
+		set_environment(value)
 
 
 
@@ -82,49 +120,49 @@ var _editing_multiple := false
 
 
 ## OnReady Variables
-onready var View2D := get_node("View2D")
+@onready var View2D := get_node("View2D")
 
-onready var View3D := get_node("View3D")
+@onready var View3D := get_node("View3D")
 
-onready var ViewPort := get_node("View3D/Viewport")
+@onready var ViewPort := get_node("View3D/Viewport")
 
-onready var CameraPivot := get_node("View3D/Viewport/CameraPivot")
+@onready var CameraPivot := get_node("View3D/Viewport/CameraPivot")
 
-onready var CameraRef := get_node("View3D/Viewport/CameraPivot/Camera")
+@onready var CameraRef := get_node("View3D/Viewport/CameraPivot/Camera")
 
-onready var VoxelPreview := get_node("View3D/Viewport/VoxelPreview")
+@onready var VoxelPreview := get_node("View3D/Viewport/VoxelPreview")
 
-onready var Select := get_node("View3D/Viewport/Select")
+@onready var Select := get_node("View3D/Viewport/Select")
 
-onready var ViewModeRef := get_node("ToolBar/ViewMode")
+@onready var ViewModeRef := get_node("ToolBar/ViewMode")
 
-onready var ViewerHint := get_node("ToolBar/Hint")
+@onready var ViewerHint := get_node("ToolBar/Hint")
 
-onready var ContextMenu := get_node("ContextMenu")
+@onready var ContextMenu := get_node("ContextMenu")
 
-onready var ColorMenu := get_node("ColorMenu")
+@onready var ColorMenu := get_node("ColorMenu")
 
-onready var VoxelColor := get_node("ColorMenu/VBoxContainer/VoxelColor")
+@onready var VoxelColor := get_node("ColorMenu/VBoxContainer/VoxelColor")
 
-onready var TextureMenu := get_node("TextureMenu")
+@onready var TextureMenu := get_node("TextureMenu")
 
-onready var VoxelTexture := get_node("TextureMenu/VBoxContainer/ScrollContainer/VoxelTexture")
+@onready var VoxelTexture := get_node("TextureMenu/VBoxContainer/ScrollContainer/VoxelTexture")
 
-onready var MaterialMenu := get_node("MaterialMenu")
+@onready var MaterialMenu := get_node("MaterialMenu")
 
-onready var MaterialRef := get_node("MaterialMenu/VBoxContainer/VBoxContainer/HBoxContainer6/Material")
+@onready var MaterialRef := get_node("MaterialMenu/VBoxContainer/VBoxContainer/HBoxContainer6/Material")
 
-onready var Metallic := get_node("MaterialMenu/VBoxContainer/VBoxContainer/HBoxContainer/Metallic")
+@onready var Metallic := get_node("MaterialMenu/VBoxContainer/VBoxContainer/HBoxContainer/Metallic")
 
-onready var Specular := get_node("MaterialMenu/VBoxContainer/VBoxContainer/HBoxContainer2/Specular")
+@onready var Specular := get_node("MaterialMenu/VBoxContainer/VBoxContainer/HBoxContainer2/Specular")
 
-onready var Roughness := get_node("MaterialMenu/VBoxContainer/VBoxContainer/HBoxContainer3/Roughness")
+@onready var Roughness := get_node("MaterialMenu/VBoxContainer/VBoxContainer/HBoxContainer3/Roughness")
 
-onready var Energy := get_node("MaterialMenu/VBoxContainer/VBoxContainer/HBoxContainer4/Energy")
+@onready var Energy := get_node("MaterialMenu/VBoxContainer/VBoxContainer/HBoxContainer4/Energy")
 
-onready var EnergyColor := get_node("MaterialMenu/VBoxContainer/VBoxContainer/HBoxContainer5/EnergyColor")
+@onready var EnergyColor := get_node("MaterialMenu/VBoxContainer/VBoxContainer/HBoxContainer5/EnergyColor")
 
-onready var EnvironmentMenu := get_node("EnvironmentMenu")
+@onready var EnvironmentMenu := get_node("EnvironmentMenu")
 
 
 
@@ -244,13 +282,13 @@ func set_voxel_set(value : Resource, update := true) -> void:
 		return
 	
 	if is_instance_valid(voxel_set):
-		if voxel_set.is_connected("requested_refresh", self, "update_view"):
-			voxel_set.disconnect("requested_refresh", self, "update_view") 
+		if voxel_set.is_connected("requested_refresh", update_view):
+			voxel_set.disconnect("requested_refresh", update_view) 
 	
 	voxel_set = value
 	if is_instance_valid(voxel_set):
-		if not voxel_set.is_connected("requested_refresh", self, "update_view"):
-			voxel_set.connect("requested_refresh", self, "update_view")
+		if not voxel_set.is_connected("requested_refresh", update_view):
+			voxel_set.connect("requested_refresh", update_view)
 	if is_instance_valid(VoxelTexture):
 		VoxelTexture.voxel_set = voxel_set
 	
@@ -346,7 +384,7 @@ func unselect(face : Vector3, emit := true) -> void:
 
 # Unselects all the faces
 func unselect_all() -> void:
-	while not _selections.empty():
+	while not _selections.is_empty():
 		unselect(_selections.back())
 
 
@@ -362,7 +400,7 @@ func update_hint() -> void:
 	if is_instance_valid(ViewerHint):
 		ViewerHint.text = ""
 		
-		if not _selections.empty():
+		if not _selections.is_empty():
 			for i in range(len(_selections)):
 				if i > 0:
 					ViewerHint.text += ", "
@@ -554,7 +592,7 @@ func _voxel_restore() -> void:
 func _on_Face_gui_input(event : InputEvent, normal : Vector3) -> void:
 	_last_hovered_face = normal
 	if event is InputEventMouseButton and event.pressed:
-		if event.button_index == BUTTON_LEFT:
+		if event.button_index == MOUSE_BUTTON_LEFT:
 			if selection_max > 0:
 				if _selections.has(normal):
 					unselect(normal)
@@ -563,7 +601,7 @@ func _on_Face_gui_input(event : InputEvent, normal : Vector3) -> void:
 				accept_event()
 			else:
 				get_voxle_button(normal).pressed = false
-		elif event.button_index == BUTTON_RIGHT:
+		elif event.button_index == MOUSE_BUTTON_RIGHT:
 			if allow_edit:
 				show_context_menu(event.global_position, _last_hovered_face)
 	update_hint()
@@ -586,7 +624,7 @@ func _on_View3D_gui_input(event : InputEvent) -> void:
 				CameraPivot.rotation_degrees.x += -motion.y * camera_sensitivity
 				CameraPivot.rotation_degrees.y += -motion.x * camera_sensitivity
 		elif event is InputEventMouseButton:
-			if event.button_index == BUTTON_LEFT:
+			if event.button_index == MOUSE_BUTTON_LEFT:
 				if event.doubleclick:
 					if not hit.empty() and selection_max > 0:
 						if _selections.has(hit["normal"]):
@@ -597,7 +635,7 @@ func _on_View3D_gui_input(event : InputEvent) -> void:
 					_is_dragging = true
 				else:
 					_is_dragging = false
-			elif event.button_index == BUTTON_RIGHT and not event.is_pressed():
+			elif event.button_index == MOUSE_BUTTON_RIGHT and not event.is_pressed():
 				show_context_menu(event.global_position, _last_hovered_face)
 		
 		if _is_dragging:
@@ -842,5 +880,5 @@ func _on_EnvironmentMenu_file_selected(path):
 	var _environment = load(path)
 	if _environment is Environment:
 		set_environment(_environment)
-		property_list_changed_notify()
+		# property_list_changed_notify()
 		save_environment()

--- a/addons/voxel-core/engine/importers/voxel_importer.gd
+++ b/addons/voxel-core/engine/importers/voxel_importer.gd
@@ -50,15 +50,21 @@ func _get_preset_name(preset : int) -> String:
 		return preset_names[preset]
 
 
-func _get_import_options(preset: int) -> Array:
-	return _get_shared_options(preset)
+func _get_import_options(path: String, preset: int) -> Array:
+	return get_shared_options(preset)
 
+func _get_priority() -> float:
+	return 0.8
 
 func _get_preset_count() -> int:
 	return Presets.size()
 
 
-func _get_option_visibility(option : String, options : Dictionary) -> bool:
+func _get_import_order() -> int:
+	return ResourceImporter.IMPORT_ORDER_DEFAULT
+
+
+func _get_option_visibility(path: String, option_name : String, options : Dictionary) -> bool:
 	return true
 
 
@@ -70,34 +76,34 @@ func join(arr: Array, delim: String):
 		res += a + delim
 
 # All "hint_string" keys where changed to be inferred arrays because of GDscript 2
-func _get_shared_options(preset : int) -> Array:
+func get_shared_options(preset : int) -> Array:
 	var preset_options = [
 		{
 			"name": "mesh_mode",
 			"default_value": VoxelMesh.MeshModes.GREEDY,
 			"property_hint": PROPERTY_HINT_ENUM,
-			"hint_string": join(VoxelMesh.MeshModes.keys(), ","),
+			"hint_string": ",".join(PackedStringArray(VoxelMesh.MeshModes.keys())),
 			"usage": PROPERTY_USAGE_EDITOR,
 		},
 		{
 			"name": "origin_x",
 			"default_value": 0,
 			"property_hint": PROPERTY_HINT_ENUM,
-			#"hint_string": Array[String](OriginX.keys()).join(","),
+			"hint_string": ",".join(PackedStringArray(OriginX.keys())),
 			"usage": PROPERTY_USAGE_EDITOR,
 		},
 		{
 			"name": "origin_y",
 			"default_value": 0,
 			"property_hint": PROPERTY_HINT_ENUM,
-			"hint_string": join(OriginY.keys(), ","),
+			"hint_string": ",".join(PackedStringArray(OriginY.keys())),
 			"usage": PROPERTY_USAGE_EDITOR,
 		},
 		{
 			"name": "origin_z",
 			"default_value": 0,
 			"property_hint": PROPERTY_HINT_ENUM,
-			"hint_string": join(OriginZ.keys(), ","),
+			"hint_string": ",".join(PackedStringArray(OriginZ.keys())),
 			"usage": PROPERTY_USAGE_EDITOR,
 		},
 		{

--- a/addons/voxel-core/engine/importers/voxel_importer.gd
+++ b/addons/voxel-core/engine/importers/voxel_importer.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends EditorImportPlugin
 class_name VoxelImporter
 # Base Class for 3d voxel importers
@@ -37,7 +37,7 @@ enum OriginZ {
 
 
 ## Built-In Virtual Methods
-func get_preset_name(preset : int) -> String:
+func _get_preset_name(preset : int) -> String:
 	var preset_keys = Presets.keys()
 	var preset_names = []
 	
@@ -50,47 +50,54 @@ func get_preset_name(preset : int) -> String:
 		return preset_names[preset]
 
 
-func get_import_options(preset: int) -> Array:
-	return get_shared_options(preset)
+func _get_import_options(preset: int) -> Array:
+	return _get_shared_options(preset)
 
 
-func get_preset_count() -> int:
+func _get_preset_count() -> int:
 	return Presets.size()
 
 
-func get_option_visibility(option : String, options : Dictionary) -> bool:
+func _get_option_visibility(option : String, options : Dictionary) -> bool:
 	return true
 
 
 ## Base Class Methods
-func get_shared_options(preset : int) -> Array:
+# Helper method since join() no longer exists on arrays
+func join(arr: Array, delim: String):
+	var res = ""
+	for a in arr:
+		res += a + delim
+
+# All "hint_string" keys where changed to be inferred arrays because of GDscript 2
+func _get_shared_options(preset : int) -> Array:
 	var preset_options = [
 		{
 			"name": "mesh_mode",
 			"default_value": VoxelMesh.MeshModes.GREEDY,
 			"property_hint": PROPERTY_HINT_ENUM,
-			"hint_string": PoolStringArray(VoxelMesh.MeshModes.keys()).join(","),
+			"hint_string": join(VoxelMesh.MeshModes.keys(), ","),
 			"usage": PROPERTY_USAGE_EDITOR,
 		},
 		{
 			"name": "origin_x",
 			"default_value": 0,
 			"property_hint": PROPERTY_HINT_ENUM,
-			"hint_string": PoolStringArray(OriginX.keys()).join(","),
+			#"hint_string": Array[String](OriginX.keys()).join(","),
 			"usage": PROPERTY_USAGE_EDITOR,
 		},
 		{
 			"name": "origin_y",
 			"default_value": 0,
 			"property_hint": PROPERTY_HINT_ENUM,
-			"hint_string": PoolStringArray(OriginY.keys()).join(","),
+			"hint_string": join(OriginY.keys(), ","),
 			"usage": PROPERTY_USAGE_EDITOR,
 		},
 		{
 			"name": "origin_z",
 			"default_value": 0,
 			"property_hint": PROPERTY_HINT_ENUM,
-			"hint_string": PoolStringArray(OriginZ.keys()).join(","),
+			"hint_string": join(OriginZ.keys(), ","),
 			"usage": PROPERTY_USAGE_EDITOR,
 		},
 		{

--- a/addons/voxel-core/engine/importers/voxel_meshes.gd
+++ b/addons/voxel-core/engine/importers/voxel_meshes.gd
@@ -1,19 +1,19 @@
-tool
+@tool
 extends VoxelImporter
 # Import files as static Mesh Resource, not to be confused with VoxelObjects
 
 
 
 ## Built-In Virtual Methods
-func get_visible_name() -> String:
+func _get_visible_name() -> String:
 	return "MeshOfVoxels"
 
 
-func get_importer_name() -> String:
+func _get_importer_name() -> String:
 	return "VoxelCore.MeshOfVoxels"
 
 
-func get_recognized_extensions() -> Array:
+func _get_recognized_extensions() -> Array:
 	return [
 		"png", "jpg",
 		"vox",
@@ -23,15 +23,15 @@ func get_recognized_extensions() -> Array:
 	]
 
 
-func get_resource_type() -> String:
+func _get_resource_type() -> String:
 	return "Mesh"
 
 
-func get_save_extension() -> String:
+func _get_save_extension() -> String:
 	return "mesh"
 
 
-func import(source_file : String, save_path : String, options : Dictionary, r_platform_variants : Array, r_gen_files : Array) -> int:
+func _import(source_file : String, save_path : String, options : Dictionary, r_platform_variants : Array, r_gen_files : Array) -> int:
 	var read := Reader.read_file(source_file)
 	var error = read.get("error", FAILED)
 	if error == OK:
@@ -65,7 +65,7 @@ func import(source_file : String, save_path : String, options : Dictionary, r_pl
 		voxel_mesh.update_mesh()
 		
 		error = ResourceSaver.save(
-			'%s.%s' % [save_path, get_save_extension()],
+			'%s.%s' % [save_path, _get_save_extension()],
 			voxel_mesh.mesh)
 		
 		voxel_mesh.free()

--- a/addons/voxel-core/engine/importers/voxel_meshes.gd
+++ b/addons/voxel-core/engine/importers/voxel_meshes.gd
@@ -21,7 +21,7 @@ func _get_recognized_extensions() -> Array:
 		#"qbt",
 		#"vxm",
 	]
-
+	
 
 func _get_resource_type() -> String:
 	return "Mesh"
@@ -35,9 +35,10 @@ func _import(source_file : String, save_path : String, options : Dictionary, r_p
 	var read := Reader.read_file(source_file)
 	var error = read.get("error", FAILED)
 	if error == OK:
+		
 		var voxel_mesh = VoxelMesh.new()
 		voxel_mesh.voxel_set = VoxelSet.new()
-		
+		print(voxel_mesh.mesh)
 		voxel_mesh.set_mesh_mode(options.get("mesh_mode", VoxelMesh.MeshModes.GREEDY))
 		voxel_mesh.voxel_set.set_voxels(read["palette"])
 		for voxel_position in read["voxels"]:
@@ -46,7 +47,6 @@ func _import(source_file : String, save_path : String, options : Dictionary, r_p
 		# voxel size
 		var voxel_size = options.get("voxel_size", 0.5)
 		voxel_mesh.set_voxel_size(voxel_size)
-		
 		# origin shift
 		var origin = get_origin_offset(options)
 		
@@ -56,17 +56,15 @@ func _import(source_file : String, save_path : String, options : Dictionary, r_p
 			clamp(origin.y + 1, 0, 1),
 			clamp(origin.z + 1, 0, 1)
 		)
-		
 		var offset = voxel_mesh.vec_to_center(origin)
 		offset = offset * offset_mult
-		
 		voxel_mesh.move(offset)
-		
 		voxel_mesh.update_mesh()
-		
+		print('%s.%s' % [save_path, _get_save_extension()], voxel_mesh.mesh)
 		error = ResourceSaver.save(
 			'%s.%s' % [save_path, _get_save_extension()],
 			voxel_mesh.mesh)
-		
+		print("Mesh checkpoint 4")
+		print(voxel_mesh.mesh)
 		voxel_mesh.free()
 	return error

--- a/addons/voxel-core/engine/importers/voxel_objects.gd
+++ b/addons/voxel-core/engine/importers/voxel_objects.gd
@@ -1,18 +1,18 @@
-tool
+@tool
 extends VoxelImporter
 # Import files as VoxelObjects
 
 
 ## Built-In Virtual Methods
-func get_visible_name() -> String:
+func _get_visible_name() -> String:
 	return "VoxelObject"
 
 
-func get_importer_name() -> String:
+func _get_importer_name() -> String:
 	return "VoxelCore.VoxelObject"
 
 
-func get_recognized_extensions() -> Array:
+func _get_recognized_extensions() -> Array:
 	return [
 		"png", "jpg",
 		"vox",
@@ -22,15 +22,15 @@ func get_recognized_extensions() -> Array:
 	]
 
 
-func get_resource_type() -> String:
+func _get_resource_type() -> String:
 	return "PackedScene"
 
 
-func get_save_extension() -> String:
+func _get_save_extension() -> String:
 	return "tscn"
 
 
-func get_import_options(preset : int) -> Array:
+func _get_import_options(preset : int) -> Array:
 	var preset_options = [
 		{
 			"name": "name",
@@ -46,12 +46,12 @@ func get_import_options(preset : int) -> Array:
 		}
 	]
 	
-	preset_options.append_array( get_shared_options(preset))
+	preset_options.append_array(_get_shared_options(preset))
 	
 	return preset_options
 
 
-func import(source_file : String, save_path : String, options : Dictionary, r_platform_variants : Array, r_gen_files : Array) -> int:
+func _import(source_file : String, save_path : String, options : Dictionary, r_platform_variants : Array, r_gen_files : Array) -> int:
 	var voxel_object
 	match options.get("voxel_object", 0):
 		_: voxel_object = VoxelMesh.new()
@@ -84,6 +84,6 @@ func import(source_file : String, save_path : String, options : Dictionary, r_pl
 		var scene = PackedScene.new()
 		error = scene.pack(voxel_object)
 		if error == OK:
-			error = ResourceSaver.save("%s.%s" % [save_path, get_save_extension()], scene)
+			error = ResourceSaver.save("%s.%s" % [save_path, _get_save_extension()], scene)
 	voxel_object.free()
 	return error

--- a/addons/voxel-core/engine/importers/voxel_objects.gd
+++ b/addons/voxel-core/engine/importers/voxel_objects.gd
@@ -30,7 +30,7 @@ func _get_save_extension() -> String:
 	return "tscn"
 
 
-func _get_import_options(preset : int) -> Array:
+func _get_import_options(path: String, preset : int) -> Array:
 	var preset_options = [
 		{
 			"name": "name",
@@ -46,7 +46,7 @@ func _get_import_options(preset : int) -> Array:
 		}
 	]
 	
-	preset_options.append_array(_get_shared_options(preset))
+	preset_options.append_array(get_shared_options(preset))
 	
 	return preset_options
 
@@ -57,10 +57,10 @@ func _import(source_file : String, save_path : String, options : Dictionary, r_p
 		_: voxel_object = VoxelMesh.new()
 	var error = voxel_object.load_file(source_file)
 	if error == OK:
-		voxel_object.set_name(source_file.get_file().replace("." + source_file.get_extension(), "") if options["name"].empty() else options["name"])
+		print("Object check 1")
+		voxel_object.set_name(source_file.get_file().replace("." + source_file.get_extension(), "") if options["name"].is_empty() else options["name"])
 		voxel_object.set_mesh_mode(options.get("mesh_mode", VoxelMesh.MeshModes.NAIVE))
 		
-		# voxel size
 		var voxel_size = options.get("voxel_size", 0.5)
 		voxel_object.set_voxel_size(voxel_size)
 		
@@ -73,17 +73,18 @@ func _import(source_file : String, save_path : String, options : Dictionary, r_p
 			clamp(origin.y + 1, 0, 1),
 			clamp(origin.z + 1, 0, 1)
 		)
-		
+		print("Object check 2")
 		var offset = voxel_object.vec_to_center(origin)
 		offset = offset * offset_mult
 		
 		voxel_object.move(offset)
 		
 		voxel_object.update_mesh()
-		
+		print("Object check3")
 		var scene = PackedScene.new()
 		error = scene.pack(voxel_object)
 		if error == OK:
 			error = ResourceSaver.save("%s.%s" % [save_path, _get_save_extension()], scene)
+		print("Object check 4")
 	voxel_object.free()
 	return error

--- a/addons/voxel-core/engine/importers/voxel_scenes.gd
+++ b/addons/voxel-core/engine/importers/voxel_scenes.gd
@@ -25,7 +25,7 @@ func _get_save_extension() -> String:
 	return "tscn"
 
 
-func _get_import_options(preset : int) -> Array:
+func _get_import_options(path: String, preset : int) -> Array:
 	var preset_options = [
 		{
 			"name": "root_name",
@@ -36,7 +36,7 @@ func _get_import_options(preset : int) -> Array:
 		}
 	]
 	
-	preset_options.append_array(_get_shared_options(preset))
+	preset_options.append_array(get_shared_options(preset))
 	
 	return preset_options
 

--- a/addons/voxel-core/engine/importers/voxel_scenes.gd
+++ b/addons/voxel-core/engine/importers/voxel_scenes.gd
@@ -1,31 +1,31 @@
-tool
+@tool
 extends VoxelImporter
 # Import vox files as scenes, maintaining seperate objects and offsets
 
 
 
 ## Built-In Virtual Methods
-func get_visible_name() -> String:
+func _get_visible_name() -> String:
 	return "MagicaVoxelScene"
 
 
-func get_importer_name() -> String:
+func _get_importer_name() -> String:
 	return "VoxelCore.MagicaVoxelScene"
 
 
-func get_recognized_extensions() -> Array:
+func _get_recognized_extensions() -> Array:
 	return ["vox"]
 
 
-func get_resource_type() -> String:
+func _get_resource_type() -> String:
 	return "PackedScene"
 
 
-func get_save_extension() -> String:
+func _get_save_extension() -> String:
 	return "tscn"
 
 
-func get_import_options(preset : int) -> Array:
+func _get_import_options(preset : int) -> Array:
 	var preset_options = [
 		{
 			"name": "root_name",
@@ -36,12 +36,12 @@ func get_import_options(preset : int) -> Array:
 		}
 	]
 	
-	preset_options.append_array( get_shared_options(preset))
+	preset_options.append_array(_get_shared_options(preset))
 	
 	return preset_options
 
 
-func import(source_file : String, save_path : String, options : Dictionary, r_platform_variants : Array, r_gen_files : Array) -> int:
+func _import(source_file : String, save_path : String, options : Dictionary, r_platform_variants : Array, r_gen_files : Array) -> int:
 	# read file without merging voxels
 	var read := VoxReader.read_file(source_file, false)
 	var error = read.get("error", FAILED)
@@ -51,7 +51,7 @@ func import(source_file : String, save_path : String, options : Dictionary, r_pl
 		var voxel_set = VoxelSet.new()
 		voxel_set.set_voxels(read["palette"])
 		
-		var root_node = Spatial.new()
+		var root_node = Node3D.new()
 		var voxel_size = options.get("voxel_size", 0.5)
 		
 		# name root node
@@ -91,7 +91,7 @@ func import(source_file : String, save_path : String, options : Dictionary, r_pl
 		error = scene.pack(root_node)
 		
 		if error == OK:
-			error = ResourceSaver.save("%s.%s" % [save_path, get_save_extension()], scene)
+			error = ResourceSaver.save("%s.%s" % [save_path, _get_save_extension()], scene)
 		
 		root_node.queue_free()
 	
@@ -101,15 +101,15 @@ func import(source_file : String, save_path : String, options : Dictionary, r_pl
 
 ## Private Methods
 # recursively builds scene from dict tree
-func _build_scene(tree : Dictionary, voxel_set : VoxelSet, root_node : Spatial, parent_node : Spatial, mesh_mode, voxel_size) -> AABB:
-	var node: Spatial
+func _build_scene(tree : Dictionary, voxel_set : VoxelSet, root_node : Node3D, parent_node : Node3D, mesh_mode, voxel_size) -> AABB:
+	var node: Node3D
 	var combined_aabb := AABB()
 	
 	if tree.type == "GROUP":
-		node = Spatial.new()
+		node = Node3D.new()
 		node.name = "Group"
 	elif tree.type == "SHAPE":
-		node = MeshInstance.new()
+		node = MeshInstance3D.new()
 		node.name = "Shape"
 		
 		var voxel_mesh = VoxelMesh.new()
@@ -146,7 +146,7 @@ func _build_scene(tree : Dictionary, voxel_set : VoxelSet, root_node : Spatial, 
 		node.transform = tree.transform
 		node.translation = node.translation * voxel_size
 	
-	if node is MeshInstance:
+	if node is MeshInstance3D:
 		combined_aabb = node.get_aabb()
 		combined_aabb.position += node.translation
 	
@@ -182,7 +182,7 @@ func _merge_aabb(aabb_a, aabb_b) -> Dictionary:
 
 # Shifts a spatials origin, by moving all its children
 # origin in fraction. -1 for no change
-func _shift_origin(node : Spatial, node_aabb : AABB, new_origin : Vector3, voxel_size : float) -> Spatial:
+func _shift_origin(node : Node3D, node_aabb : AABB, new_origin : Vector3, voxel_size : float) -> Node3D:
 	if new_origin == Vector3(-1.0, -1.0, -1.0):
 		return node
 	

--- a/addons/voxel-core/engine/importers/voxel_sets.gd
+++ b/addons/voxel-core/engine/importers/voxel_sets.gd
@@ -2,7 +2,6 @@
 extends EditorImportPlugin
 
 
-
 ## Enums
 enum Presets { DEFAULT }
 
@@ -23,6 +22,10 @@ func _get_recognized_extensions() -> Array:
 		"vox",
 		"gpl",
 	]
+	
+	
+func _get_priority() -> float:
+	return 0.8
 
 
 func _get_resource_type() -> String:
@@ -45,7 +48,7 @@ func _get_preset_name(preset : int) -> String:
 			return "Unknown"
 
 
-func _get_import_options(preset : int) -> Array:
+func _get_import_options(path: String, preset : int) -> Array:
 	var preset_options = [
 		
 	]
@@ -53,7 +56,7 @@ func _get_import_options(preset : int) -> Array:
 	return preset_options
 
 
-func _get_option_visibility(option : String, options : Dictionary) -> bool:
+func _get_option_visibility(path: String, option : String, options : Dictionary) -> bool:
 	return true
 
 

--- a/addons/voxel-core/engine/importers/voxel_sets.gd
+++ b/addons/voxel-core/engine/importers/voxel_sets.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends EditorImportPlugin
 
 
@@ -9,15 +9,15 @@ enum Presets { DEFAULT }
 
 
 ## Built-In Virtual Methods
-func get_visible_name() -> String:
+func _get_visible_name() -> String:
 	return "VoxelSet"
 
 
-func get_importer_name() -> String:
+func _get_importer_name() -> String:
 	return "VoxelCore.VoxelSet"
 
 
-func get_recognized_extensions() -> Array:
+func _get_recognized_extensions() -> Array:
 	return [
 		"png", "jpg",
 		"vox",
@@ -25,19 +25,19 @@ func get_recognized_extensions() -> Array:
 	]
 
 
-func get_resource_type() -> String:
+func _get_resource_type() -> String:
 	return "Resource"
 
 
-func get_save_extension() -> String:
+func _get_save_extension() -> String:
 	return "tres"
 
 
-func get_preset_count() -> int:
+func _get_preset_count() -> int:
 	return Presets.size()
 
 
-func get_preset_name(preset : int) -> String:
+func _get_preset_name(preset : int) -> String:
 	match preset:
 		Presets.DEFAULT:
 			return "Default"
@@ -45,7 +45,7 @@ func get_preset_name(preset : int) -> String:
 			return "Unknown"
 
 
-func get_import_options(preset : int) -> Array:
+func _get_import_options(preset : int) -> Array:
 	var preset_options = [
 		
 	]
@@ -53,14 +53,14 @@ func get_import_options(preset : int) -> Array:
 	return preset_options
 
 
-func get_option_visibility(option : String, options : Dictionary) -> bool:
+func _get_option_visibility(option : String, options : Dictionary) -> bool:
 	return true
 
 
-func import(source_file : String, save_path : String, options : Dictionary, r_platform_variants : Array, r_gen_files : Array) -> int:
+func _import(source_file : String, save_path : String, options : Dictionary, r_platform_variants : Array, r_gen_files : Array) -> int:
 	var voxel_set := VoxelSet.new()
 	var error = voxel_set.load_file(source_file)
 	if error == OK:
 		voxel_set.request_refresh()
-		error = ResourceSaver.save("%s.%s" % [save_path, get_save_extension()], voxel_set)
+		error = ResourceSaver.save("%s.%s" % [save_path, _get_save_extension()], voxel_set)
 	return error

--- a/addons/voxel-core/engine/voxel_object_editor/editor_selection/editor_selection.gd
+++ b/addons/voxel-core/engine/voxel_object_editor/editor_selection/editor_selection.gd
@@ -1,5 +1,5 @@
-tool
-extends Reference
+@tool
+extends RefCounted
 
 
 

--- a/addons/voxel-core/engine/voxel_object_editor/editor_selection/editor_selections/area.gd
+++ b/addons/voxel-core/engine/voxel_object_editor/editor_selection/editor_selections/area.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends "res://addons/voxel-core/engine/voxel_object_editor/editor_selection/editor_selection.gd"
 
 
@@ -24,13 +24,13 @@ func select(editor, event : InputEventMouse, prev_hit : Dictionary) -> bool:
 			_selection.append(editor.get_selection())
 			_selection.append(editor.get_selection())
 		else:
-			if not _selection.empty():
+			if not _selection.is_empty():
 				editor.work_tool()
 				_selection.clear()
 	elif event is InputEventMouseMotion:
 		if not (editor.last_hit.get("position") == prev_hit.get("position") and editor.last_hit.get("normal") == prev_hit.get("normal")):
 			if not editor.last_hit.empty():
-				if _selection.empty():
+				if _selection.is_empty():
 					editor.set_cursors_selections([editor.get_selection()])
 				else:
 					_selection[1] = editor.get_selection()

--- a/addons/voxel-core/engine/voxel_object_editor/editor_selection/editor_selections/extrude.gd
+++ b/addons/voxel-core/engine/voxel_object_editor/editor_selection/editor_selections/extrude.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends "res://addons/voxel-core/engine/voxel_object_editor/editor_selection/editor_selection.gd"
 
 
@@ -29,7 +29,7 @@ func select(editor, event : InputEventMouse, prev_hit : Dictionary) -> bool:
 	
 	if event is InputEventMouseButton:
 		if event.is_pressed():
-			if not _face.empty():
+			if not _face.is_empty():
 				_extruding = true
 				_extrude_normal = editor.last_hit["normal"]
 		else:

--- a/addons/voxel-core/engine/voxel_object_editor/editor_selection/editor_selections/individual.gd
+++ b/addons/voxel-core/engine/voxel_object_editor/editor_selection/editor_selections/individual.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends "res://addons/voxel-core/engine/voxel_object_editor/editor_selection/editor_selection.gd"
 
 
@@ -15,7 +15,7 @@ func select(editor, event : InputEventMouse, prev_hit : Dictionary) -> bool:
 	
 	if (event is InputEventMouseButton and not event.pressed) and not editor.last_hit.empty():
 		editor.work_tool()
-	elif Input.is_mouse_button_pressed(BUTTON_LEFT) and Input.is_key_pressed(KEY_SHIFT):
+	elif Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT) and Input.is_key_pressed(KEY_SHIFT):
 		editor.work_tool()
 	
 	if not (editor.last_hit.get("position") == prev_hit.get("position") and editor.last_hit.get("normal") == prev_hit.get("normal")):

--- a/addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tool.gd
+++ b/addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tool.gd
@@ -1,5 +1,5 @@
-tool
-extends Reference
+@tool
+extends RefCounted
 
 
 
@@ -11,7 +11,7 @@ var name := ""
 var tool_normal := 0
 
 # Types of selection modes
-var selection_modes := PoolStringArray([
+var selection_modes := PackedStringArray([
 	"individual",
 	"area",
 	"extrude",

--- a/addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tools/add.gd
+++ b/addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tools/add.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends "res://addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tool.gd"
 
 

--- a/addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tools/fill.gd
+++ b/addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tools/fill.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends "res://addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tool.gd"
 
 
@@ -6,7 +6,7 @@ extends "res://addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_t
 ## Built-In Virtual Methods
 func _init():
 	name = "fill"
-	selection_modes = PoolStringArray([
+	selection_modes = PackedStringArray([
 		"individual"
 	])
 

--- a/addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tools/pick.gd
+++ b/addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tools/pick.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends "res://addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tool.gd"
 
 
@@ -6,7 +6,7 @@ extends "res://addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_t
 ## Built-In Virtual Methods
 func _init():
 	name = "pick"
-	selection_modes = PoolStringArray([
+	selection_modes = PackedStringArray([
 		"individual"
 	])
 	mirror_modes = Vector3.ZERO

--- a/addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tools/sub.gd
+++ b/addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tools/sub.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends "res://addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tool.gd"
 
 

--- a/addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tools/swap.gd
+++ b/addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tools/swap.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends "res://addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tool.gd"
 
 

--- a/addons/voxel-core/engine/voxel_object_editor/voxel_cursor/voxel_cursor.gd
+++ b/addons/voxel-core/engine/voxel_object_editor/voxel_cursor/voxel_cursor.gd
@@ -53,13 +53,13 @@ func set_voxel_size(value : float, update := true) -> void:
 
 
 func set_color(value : Color) -> void:
-	color = value
+	_color = value
 	if is_instance_valid(material_override):
 		material_override.albedo_color = color
 
 
 func set_selections(value : Array, update := true) -> void:
-	selections = value
+	_selections = value
 	
 	if update:
 		self.update()

--- a/addons/voxel-core/engine/voxel_object_editor/voxel_cursor/voxel_cursor.gd
+++ b/addons/voxel-core/engine/voxel_object_editor/voxel_cursor/voxel_cursor.gd
@@ -1,12 +1,17 @@
-tool
-extends MeshInstance
+@tool
+extends MeshInstance3D
 # Mesh used to highlight voxel grid selections
 
 
 
 ## Exported Variables
 # Highlight color
-export var color := Color(1, 1, 1, 0.75) setget set_color
+var _color: Color = Color(1, 1, 1, 0.75)
+@export var color: Color: 
+	get:
+		return _color
+	set(value):
+		set_color(value)
 
 
 
@@ -15,7 +20,12 @@ export var color := Color(1, 1, 1, 0.75) setget set_color
 # A Vector3 highlights a single grid position
 # [Vector3, Vector3] highlights the area between two grid positions
 # Many type of selections can be mixed and selected at a time
-var selections := [] setget set_selections
+var _selections: Array = []
+var selections: Array:
+	get:
+		return _selections
+	set(value):
+		set_selections(value)
 
 
 
@@ -58,7 +68,7 @@ func set_selections(value : Array, update := true) -> void:
 # Setup the material if not already done
 func setup() -> void:
 	if not is_instance_valid(material_override):
-		material_override = SpatialMaterial.new()
+		material_override = StandardMaterial3D.new()
 	material_override.flags_transparent = true
 	material_override.flags_unshaded = true
 	material_override.params_grow = true
@@ -69,7 +79,7 @@ func setup() -> void:
 
 # Update highlighted position(s) / area(s)
 func update() -> void:
-	if not selections.empty():
+	if not selections.is_empty():
 		_voxel_tool.begin()
 		var voxel := Voxel.colored(color)
 		for selection in selections:

--- a/addons/voxel-core/engine/voxel_object_editor/voxel_grid/voxel_grid.gd
+++ b/addons/voxel-core/engine/voxel_object_editor/voxel_grid/voxel_grid.gd
@@ -1,5 +1,5 @@
-tool
-extends MeshInstance
+@tool
+extends MeshInstance3D
 # Grid Mesh used by VoxelObjectEditor
 
 
@@ -10,13 +10,33 @@ enum GridModes { SOLID, WIRED }
 
 
 ## Exported Variables
-export var disabled := false setget set_disabled
+var _disabled: bool = false
+@export var disabled: bool:
+	get:
+		return _disabled
+	set(value):
+		set_disabled(value)
 
-export(Color, RGB) var color := Color.white setget set_modulate
+var _color: Color = Color.WHITE
+@export var color: Color:
+	get:
+		return _color
+	set(value):
+		set_modulate(value)
 
-export(GridModes) var grid_mode := GridModes.WIRED setget set_grid_mode
+var _grid_mode: GridModes = GridModes.WIRED
+@export var grid_mode: GridModes:
+	get:
+		return _grid_mode
+	set(value):
+		set_grid_mode(value)
 
-export var grid_size := Vector3(16, 16, 16) setget set_grid_size
+var _grid_size: Vector3 = Vector3(16, 16, 16)
+@export var grid_size: Vector3:
+	get:
+		return _grid_size
+	set(value):
+		set_grid_size(value)
 
 
 
@@ -74,7 +94,7 @@ func set_grid_size(value : Vector3, update := true) -> void:
 
 func setup() -> void:
 	if not is_instance_valid(material_override):
-		material_override = SpatialMaterial.new()
+		material_override = StandardMaterial3D.new()
 	material_override.albedo_color = color
 	material_override.set_cull_mode(2)
 	update()

--- a/addons/voxel-core/engine/voxel_object_editor/voxel_grid/voxel_grid.gd
+++ b/addons/voxel-core/engine/voxel_object_editor/voxel_grid/voxel_grid.gd
@@ -58,7 +58,7 @@ func _ready() -> void:
 
 ## Public Methods
 func set_disabled(value : bool) -> void:
-	disabled = value
+	_disabled = value
 	visible = not disabled
 	find_node("CollisionShape", true, false).disabled = disabled
 
@@ -70,20 +70,20 @@ func set_voxel_size(value : float, update := true) -> void:
 		self.update()
 
 func set_modulate(value : Color) -> void:
-	color = value
+	_color = value
 	
 	material_override.albedo_color = color
 
 
 func set_grid_mode(value : int, update := true) -> void:
-	grid_mode = value
+	_grid_mode = value
 	
 	if update:
 		self.update()
 
 
 func set_grid_size(value : Vector3, update := true) -> void:
-	grid_size = Vector3(
+	_grid_size = Vector3(
 			clamp(value.x, 1, 100),
 			clamp(value.y, 1, 100),
 			clamp(value.z, 1, 100))

--- a/addons/voxel-core/engine/voxel_object_editor/voxel_object_editor.gd
+++ b/addons/voxel-core/engine/voxel_object_editor/voxel_object_editor.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends Control
 
 
@@ -26,14 +26,15 @@ const VoxelCursor := preload("res://addons/voxel-core/engine/voxel_object_editor
 const VoxelObject := preload("res://addons/voxel-core/classes/voxel_object.gd")
 
 # Default editor config
-const ConfigDefault := {
+# CHANGED TO VAR BECAUSE OF GDScript 2
+var ConfigDefault := {
 	"cursor.visible": true,
 	"cursor.dynamic": true,
 	"cursor.voxel_raycasting": false,
-	"cursor.color": Color.white,
+	"cursor.color": Color.WHITE,
 	"grid.visible": true,
 	"grid.mode": VoxelGrid.GridModes.WIRED,
-	"grid.color": Color.white,
+	"grid.color": Color.WHITE,
 	"grid.constant": true,
 	"grid.size": Vector2(16, 16),
 }
@@ -51,7 +52,12 @@ var last_hit := {}
 var config := {}
 
 # Reference to VoxelObject being edited
-var voxel_object : VoxelObject setget start_editing
+var _voxel_object: VoxelObject
+var voxel_object: VoxelObject:
+	get:
+		return _voxel_object
+	set(value):
+		start_editing(value)
 
 
 
@@ -61,9 +67,9 @@ var _grid := VoxelGrid.new()
 
 # Colletions of loaded editor selection modes
 var _selection_modes := [
-	preload("res://addons/voxel-core/engine/voxel_object_editor/editor_selection/editor_selections/individual.gd").new(),
-	preload("res://addons/voxel-core/engine/voxel_object_editor/editor_selection/editor_selections/area.gd").new(),
-	preload("res://addons/voxel-core/engine/voxel_object_editor/editor_selection/editor_selections/extrude.gd").new(),
+	preload("res://addons/voxel-core/engine/voxel_object_editor/editor_selection/editor_selections/individual.gd").new() as Object,
+	preload("res://addons/voxel-core/engine/voxel_object_editor/editor_selection/editor_selections/area.gd").new() as Object,
+	preload("res://addons/voxel-core/engine/voxel_object_editor/editor_selection/editor_selections/extrude.gd").new() as Object,
 ]
 
 # Refrence to editor's voxel cursors
@@ -80,11 +86,11 @@ var _cursors := {
 
 # Collection of loaded editor tools
 var _tools := [
-	preload("res://addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tools/add.gd").new(),
-	preload("res://addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tools/sub.gd").new(),
-	preload("res://addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tools/swap.gd").new(),
-	preload("res://addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tools/fill.gd").new(),
-	preload("res://addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tools/pick.gd").new(),
+	preload("res://addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tools/add.gd").new() as Object,
+	preload("res://addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tools/sub.gd").new() as Object,
+	preload("res://addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tools/swap.gd").new() as Object,
+	preload("res://addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tools/fill.gd").new() as Object,
+	preload("res://addons/voxel-core/engine/voxel_object_editor/editor_tool/editor_tools/pick.gd").new() as Object,
 ]
 
 # Voxel id of each palette
@@ -96,75 +102,75 @@ var import_file_path := ""
 
 
 ## OnReady Variables
-onready var Editing := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/HBoxContainer/Editing")
+@onready var Editing := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/HBoxContainer/Editing")
 
-onready var Options := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Options")
+@onready var Options := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Options")
 
-onready var Tool := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Options/VBoxContainer/HBoxContainer/Tool")
+@onready var Tool := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Options/VBoxContainer/HBoxContainer/Tool")
 
-onready var Palette := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Options/VBoxContainer/HBoxContainer/Palette")
+@onready var Palette := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Options/VBoxContainer/HBoxContainer/Palette")
 
-onready var SelectionMode := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Options/VBoxContainer/HBoxContainer/SelectionMode")
+@onready var SelectionMode := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Options/VBoxContainer/HBoxContainer/SelectionMode")
 
-onready var MirrorX := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Options/VBoxContainer/HBoxContainer2/MirrorX")
+@onready var MirrorX := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Options/VBoxContainer/HBoxContainer2/MirrorX")
 
-onready var MirrorY := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Options/VBoxContainer/HBoxContainer2/MirrorY")
+@onready var MirrorY := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Options/VBoxContainer/HBoxContainer2/MirrorY")
 
-onready var MirrorZ := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Options/VBoxContainer/HBoxContainer2/MirrorZ")
+@onready var MirrorZ := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Options/VBoxContainer/HBoxContainer2/MirrorZ")
 
-onready var VoxelSize := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer2/ScrollContainer/VBoxContainer/VoxelSize/Size")
+@onready var VoxelSize := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer2/ScrollContainer/VBoxContainer/VoxelSize/Size")
 
-onready var ColorChooser := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Options/VBoxContainer/ColorChooser")
+@onready var ColorChooser := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Options/VBoxContainer/ColorChooser")
 
-onready var ColorPicked := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Options/VBoxContainer/ColorChooser/ColorPicked")
+@onready var ColorPicked := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Options/VBoxContainer/ColorChooser/ColorPicked")
 
-onready var VoxelSetViewer := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Options/VoxelSetViewer")
+@onready var VoxelSetViewer := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Options/VoxelSetViewer")
 
-onready var Notice := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Notice")
+@onready var Notice := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer/Notice")
 
-onready var MoveX := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer2/ScrollContainer/VBoxContainer/Move/X")
+@onready var MoveX := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer2/ScrollContainer/VBoxContainer/Move/X")
 
-onready var MoveY := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer2/ScrollContainer/VBoxContainer/Move/Y")
+@onready var MoveY := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer2/ScrollContainer/VBoxContainer/Move/Y")
 
-onready var MoveZ := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer2/ScrollContainer/VBoxContainer/Move/Z")
+@onready var MoveZ := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer2/ScrollContainer/VBoxContainer/Move/Z")
 
-onready var CenterX := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer2/ScrollContainer/VBoxContainer/Center/X")
+@onready var CenterX := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer2/ScrollContainer/VBoxContainer/Center/X")
 
-onready var CenterY := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer2/ScrollContainer/VBoxContainer/Center/Y")
+@onready var CenterY := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer2/ScrollContainer/VBoxContainer/Center/Y")
 
-onready var CenterZ := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer2/ScrollContainer/VBoxContainer/Center/Z")
+@onready var CenterZ := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer2/ScrollContainer/VBoxContainer/Center/Z")
 
-onready var ImportMenu := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer2/ScrollContainer/VBoxContainer/File/Import/ImportFile")
+@onready var ImportMenu := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer2/ScrollContainer/VBoxContainer/File/Import/ImportFile")
 
-onready var ImportHow := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer2/ScrollContainer/VBoxContainer/File/Import/ImportHow")
+@onready var ImportHow := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer2/ScrollContainer/VBoxContainer/File/Import/ImportHow")
 
-onready var Settings := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings")
+@onready var Settings := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings")
 
-onready var CursorVisible := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings/Cursor/ScrollContainer/VBoxContainer/CursorVisible")
+@onready var CursorVisible := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings/Cursor/ScrollContainer/VBoxContainer/CursorVisible")
 
-onready var CursorDynamic := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings/Cursor/ScrollContainer/VBoxContainer/CursorDynamic")
+@onready var CursorDynamic := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings/Cursor/ScrollContainer/VBoxContainer/CursorDynamic")
 
-onready var VoxelRaycasting := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings/Cursor/ScrollContainer/VBoxContainer/VoxelRaycasting")
+@onready var VoxelRaycasting := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings/Cursor/ScrollContainer/VBoxContainer/VoxelRaycasting")
 
-onready var CursorColor := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings/Cursor/ScrollContainer/VBoxContainer/HBoxContainer/CursorColor")
+@onready var CursorColor := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings/Cursor/ScrollContainer/VBoxContainer/HBoxContainer/CursorColor")
 
-onready var GridVisible := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings/Grid/ScrollContainer/VBoxContainer/GridVisible")
+@onready var GridVisible := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings/Grid/ScrollContainer/VBoxContainer/GridVisible")
 
-onready var GridConstant := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings/Grid/ScrollContainer/VBoxContainer/GridConstant")
+@onready var GridConstant := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings/Grid/ScrollContainer/VBoxContainer/GridConstant")
 
-onready var GridMode := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings/Grid/ScrollContainer/VBoxContainer/GridMode")
+@onready var GridMode := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings/Grid/ScrollContainer/VBoxContainer/GridMode")
 
-onready var GridColor := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings/Grid/ScrollContainer/VBoxContainer/HBoxContainer2/GridColor")
+@onready var GridColor := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings/Grid/ScrollContainer/VBoxContainer/HBoxContainer2/GridColor")
 
-onready var GridSizeX := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings/Grid/ScrollContainer/VBoxContainer/VBoxContainer/Size/X")
+@onready var GridSizeX := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings/Grid/ScrollContainer/VBoxContainer/VBoxContainer/Size/X")
 
-onready var GridSizeZ := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings/Grid/ScrollContainer/VBoxContainer/VBoxContainer/Size/Z")
+@onready var GridSizeZ := get_node("VoxelObjectEditor/HBoxContainer/VBoxContainer3/Settings/Grid/ScrollContainer/VBoxContainer/VBoxContainer/Size/Z")
 
-onready var ColorMenu := get_node("ColorMenu")
+@onready var ColorMenu := get_node("ColorMenu")
 
-onready var ColorMenuColor := get_node("ColorMenu/VBoxContainer/Color")
+@onready var ColorMenuColor := get_node("ColorMenu/VBoxContainer/Color")
 
-onready var ColorMenuAdd := get_node("ColorMenu/VBoxContainer/HBoxContainer/Add")
+@onready var ColorMenuAdd := get_node("ColorMenu/VBoxContainer/HBoxContainer/Add")
 
 
 
@@ -375,7 +381,7 @@ func get_mirrors() -> Array:
 
 # Gets the user's current voxel grid selection
 func get_selection() -> Vector3:
-	return Vector3.INF if last_hit.empty() else (last_hit["position"] + last_hit["normal"] * _tools[Tool.get_selected_id()].tool_normal)
+	return Vector3(INF, INF, INF) if last_hit.is_empty() else (last_hit["position"] + last_hit["normal"] * _tools[Tool.get_selected_id()].tool_normal)
 
 
 # Gets each of the user's voxel grid selection with mirror applied
@@ -393,7 +399,7 @@ func set_cursors_voxel_size(size: float) -> void:
 
 
 # Sets the cursors visiblity
-func set_cursors_visibility(visible := Editing.pressed) -> void:
+func set_cursors_visibility(visible: bool = Editing.pressed) -> void:
 	_cursors[Vector3.ZERO].visible = visible and CursorVisible.pressed
 	var mirrors := get_mirrors()
 	for cursor in _cursors:
@@ -403,7 +409,7 @@ func set_cursors_visibility(visible := Editing.pressed) -> void:
 
 # Sets the cursors selection
 func set_cursors_selections(
-		selections := [last_hit["position"] + last_hit["normal"] * _tools[Tool.get_selected_id()].tool_normal] if not last_hit.empty() else []
+		selections := [last_hit["position"] + last_hit["normal"] * _tools[Tool.get_selected_id()].tool_normal] if not last_hit.is_empty() else []
 	) -> void:
 	_cursors[Vector3.ZERO].selections = selections
 	var mirrors := get_mirrors()
@@ -527,20 +533,20 @@ func reset_config() -> void:
 
 
 # Attempts to raycast for the VoxelObject
-func raycast_for(camera : Camera, screen_position : Vector2, target : Node) -> Dictionary:
+func raycast_for(camera : Camera3D, screen_position : Vector2, target : Node) -> Dictionary:
 	var hit := {}
 	var from := camera.project_ray_origin(screen_position)
 	var direction := camera.project_ray_normal(screen_position)
 	
 	if VoxelRaycasting.pressed:
 		hit = voxel_object.intersect_ray(
-				from, direction, 64, funcref(self, "_raycast_stop"))
+				from, direction, 64, _raycast_stop)
 	else:
 		var exclude := []
 		var to := from + direction * 1000
 		while true:
 			hit = camera.get_world().direct_space_state.intersect_ray(from, to, exclude)
-			if not hit.empty():
+			if not hit.is_empty():
 				if target.is_a_parent_of(hit.collider):
 					if _grid.is_a_parent_of(hit.collider):
 						hit["normal"] = Vector3.ZERO
@@ -645,8 +651,8 @@ func start_editing(new_voxel_object : VoxelObject) -> void:
 	update_object_params()
 	
 	setup_voxel_set(voxel_object.voxel_set)
-	voxel_object.connect("set_voxel_set", self, "setup_voxel_set")
-	voxel_object.connect("tree_exiting", self, "stop_editing", [true])
+	voxel_object.connect("on_voxel_set_changed", setup_voxel_set)
+	voxel_object.connect("tree_exiting", stop_editing, [true])
 
 
 # Disconnect currently edited VoxelObject
@@ -656,8 +662,8 @@ func stop_editing(close := false) -> void:
 		
 		detach_editor_components()
 		
-		voxel_object.disconnect("set_voxel_set", self, "setup_voxel_set")
-		voxel_object.disconnect("tree_exiting", self, "stop_editing")
+		voxel_object.disconnect("on_voxel_set_changed", setup_voxel_set)
+		voxel_object.disconnect("tree_exiting", stop_editing)
 	
 	Editing.pressed = false
 	voxel_object = null
@@ -675,13 +681,13 @@ func work_tool() -> void:
 
 
 # Handles editor input
-func handle_input(camera : Camera, event : InputEvent) -> bool:
+func handle_input(camera : Camera3D, event : InputEvent) -> bool:
 	if is_instance_valid(voxel_object):
 		if event is InputEventMouse:
 			var prev_hit = last_hit
 			last_hit = raycast_for(camera, event.position, voxel_object)
 			if Editing.pressed:
-				if event.button_mask & ~BUTTON_MASK_LEFT > 0 or (event is InputEventMouseButton and not event.button_index == BUTTON_LEFT):
+				if event.button_mask & ~MOUSE_BUTTON_MASK_LEFT > 0 or (event is InputEventMouseButton and not event.button_index == MOUSE_BUTTON_LEFT):
 					set_cursors_visibility(false)
 					return false
 				
@@ -698,7 +704,7 @@ func handle_input(camera : Camera, event : InputEvent) -> bool:
 
 
 # Shows color menu centered
-func show_color_menu(color := ColorPicked.color) -> void:
+func show_color_menu(color: Color = ColorPicked.color) -> void:
 	ColorMenuColor.color = color
 	ColorMenu.popup_centered()
 	ColorMenu.set_as_minsize()

--- a/addons/voxel-core/engine/voxel_set_editor/voxel_set_editor.gd
+++ b/addons/voxel-core/engine/voxel_set_editor/voxel_set_editor.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends ScrollContainer
 
 
@@ -10,8 +10,12 @@ signal close
 
 
 ## Exported Variables
-export(Resource) var voxel_set = null setget set_voxel_set
-
+var _voxel_set: Resource = null
+@export var voxel_set: Resource:
+	get:
+		return _voxel_set
+	set(value):
+		set_voxel_set(value)
 
 
 ## Public Variables
@@ -25,25 +29,25 @@ var import_file_path := ""
 
 
 ## OnReady Variables
-onready var ImportMenu := get_node("HBoxContainer/VBoxContainer/HBoxContainer/HBoxContainer/Import/ImportFile")
+@onready var ImportMenu := get_node("HBoxContainer/VBoxContainer/HBoxContainer/HBoxContainer/Import/ImportFile")
 
-onready var ImportHow := get_node("HBoxContainer/VBoxContainer/HBoxContainer/HBoxContainer/Import/ImportHow")
+@onready var ImportHow := get_node("HBoxContainer/VBoxContainer/HBoxContainer/HBoxContainer/Import/ImportHow")
 
-onready var VoxelSetInfo := get_node("HBoxContainer/VBoxContainer/VoxelSetInfo")
+@onready var VoxelSetInfo := get_node("HBoxContainer/VBoxContainer/VoxelSetInfo")
 
-onready var VoxelInfo := get_node("HBoxContainer/VBoxContainer/VoxelInfo")
+@onready var VoxelInfo := get_node("HBoxContainer/VBoxContainer/VoxelInfo")
 
-onready var VoxelID := get_node("HBoxContainer/VBoxContainer/VoxelInfo/HBoxContainer/VoxelID")
+@onready var VoxelID := get_node("HBoxContainer/VBoxContainer/VoxelInfo/HBoxContainer/VoxelID")
 
-onready var VoxelName := get_node("HBoxContainer/VBoxContainer/VoxelInfo/HBoxContainer/VoxelName")
+@onready var VoxelName := get_node("HBoxContainer/VBoxContainer/VoxelInfo/HBoxContainer/VoxelName")
 
-onready var VoxelData := get_node("HBoxContainer/VBoxContainer/VoxelInfo/VoxelData")
+@onready var VoxelData := get_node("HBoxContainer/VBoxContainer/VoxelInfo/VoxelData")
 
-onready var VoxelSetViewer := get_node("HBoxContainer/VBoxContainer2/VoxelSetViewer")
+@onready var VoxelSetViewer := get_node("HBoxContainer/VBoxContainer2/VoxelSetViewer")
 
-onready var VoxelInspector := get_node("HBoxContainer/VoxelInspector")
+@onready var VoxelInspector := get_node("HBoxContainer/VoxelInspector")
 
-onready var VoxelViewer := get_node("HBoxContainer/VoxelInspector/VoxelViewer")
+@onready var VoxelViewer := get_node("HBoxContainer/VoxelInspector/VoxelViewer")
 
 
 
@@ -65,13 +69,13 @@ func set_voxel_set(value : Resource, update := true) -> void:
 		return
 	
 	if is_instance_valid(voxel_set):
-		if voxel_set.is_connected("requested_refresh", self, "update_view"):
-			voxel_set.disconnect("requested_refresh", self, "update_view") 
+		if voxel_set.is_connected("requested_refresh", update_view):
+			voxel_set.disconnect("requested_refresh", update_view) 
 	
 	voxel_set = value
 	if is_instance_valid(voxel_set):
-		if not voxel_set.is_connected("requested_refresh", self, "update_view"):
-			voxel_set.connect("requested_refresh", self, "update_view")
+		if not voxel_set.is_connected("requested_refresh", update_view):
+			voxel_set.connect("requested_refresh", update_view)
 	if is_instance_valid(VoxelSetViewer):
 		VoxelSetViewer.voxel_set = voxel_set
 	
@@ -188,7 +192,7 @@ func _on_VoxelName_text_entered(new_name : String):
 		return
 	
 	var _voxel = voxel.duplicate(true)
-	if new_name.empty():
+	if new_name.is_empty():
 		undo_redo.create_action("VoxelSetEditor : Remove voxel name")
 		Voxel.remove_name(_voxel)
 	else:

--- a/addons/voxel-core/engine/voxel_set_editor/voxel_set_editor.gd
+++ b/addons/voxel-core/engine/voxel_set_editor/voxel_set_editor.gd
@@ -70,12 +70,12 @@ func set_voxel_set(value : Resource, update := true) -> void:
 	
 	if is_instance_valid(voxel_set):
 		if voxel_set.is_connected("requested_refresh", update_view):
-			voxel_set.disconnect("requested_refresh", update_view) 
+			_voxel_set.disconnect("requested_refresh", update_view) 
 	
 	voxel_set = value
 	if is_instance_valid(voxel_set):
 		if not voxel_set.is_connected("requested_refresh", update_view):
-			voxel_set.connect("requested_refresh", update_view)
+			_voxel_set.connect("requested_refresh", update_view)
 	if is_instance_valid(VoxelSetViewer):
 		VoxelSetViewer.voxel_set = voxel_set
 	

--- a/addons/voxel-core/plugin.cfg
+++ b/addons/voxel-core/plugin.cfg
@@ -3,5 +3,5 @@
 name="Voxel-Core"
 description="Voxel plugin for the Godot game engine!"
 author="ClarkThyLord"
-version="3.0.0"
+version="3.1.0"
 script="voxel-core.gd"

--- a/addons/voxel-core/voxel-core.gd
+++ b/addons/voxel-core/voxel-core.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends EditorPlugin
 
 
@@ -52,8 +52,8 @@ func _enter_tree():
 	add_import_plugin(VoxelSets)
 	add_import_plugin(VoxelScenes)
 	
-	connect("scene_closed", self, "_on_scene_closed")
-	connect("main_screen_changed", self, "_on_main_screen_changed")
+	connect("scene_closed", _on_scene_closed)
+	connect("main_screen_changed", _on_main_screen_changed)
 	
 	print("Voxel-Core is active...")
 
@@ -96,7 +96,7 @@ func edit(object):
 			return true
 
 
-func forward_spatial_gui_input(camera : Camera, event : InputEvent) -> bool:
+func forward_spatial_gui_input(camera : Camera3D, event : InputEvent) -> bool:
 	return voxel_object_editor.handle_input(camera, event) if is_instance_valid(voxel_object_editor) else false
 
 


### PR DESCRIPTION
Begin migration to Godot 4.0. All gdscript has been (naively) translated to gdscript 2. Plugin currently crashes the editor with a stack overflow on startup, so this should probably be merged into a temporary branch.